### PR TITLE
fix: clean task descriptions when syncing to CalDAV

### DIFF
--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -160,6 +160,100 @@ describe('SyncEngine', () => {
         });
     });
 
+    describe('Description cleaning (bd-2, bd-4)', () => {
+        it('should remove [id::xxx] from description (bd-4)', () => {
+            const result = (syncEngine as any).cleanTaskDescription('Buy groceries [id::test-001]');
+            expect(result).toBe('Buy groceries');
+        });
+
+        it('should remove hashtags from description (bd-2)', () => {
+            const result = (syncEngine as any).cleanTaskDescription('Buy groceries #sync #shopping');
+            expect(result).toBe('Buy groceries');
+        });
+
+        it('should remove tags and ID together', () => {
+            const result = (syncEngine as any).cleanTaskDescription('Buy groceries #sync [id::test-001]');
+            expect(result).toBe('Buy groceries');
+        });
+
+        it('should handle multiple tags', () => {
+            const result = (syncEngine as any).cleanTaskDescription('Complete project #work #urgent [id::proj-123]');
+            expect(result).toBe('Complete project');
+        });
+
+        it('should preserve description text with special characters', () => {
+            const input = 'Review @john\'s PR #42 from 2025-11-14 [id::rev-001] #sync';
+            const result = (syncEngine as any).cleanTaskDescription(input);
+            // Should keep "@john's PR #42 from 2025-11-14" but remove #sync and [id::rev-001]
+            expect(result).toBe('Review @john\'s PR #42 from 2025-11-14');
+        });
+
+        it('should clean up extra whitespace', () => {
+            const messy = 'Task   with    spaces  #tag   [id::123]';
+            const result = (syncEngine as any).cleanTaskDescription(messy);
+            expect(result).toBe('Task with spaces');
+        });
+
+        it('should handle description with only metadata', () => {
+            const result = (syncEngine as any).cleanTaskDescription('#sync [id::test-001]');
+            expect(result).toBe('');
+        });
+
+        it('should handle empty description', () => {
+            const result = (syncEngine as any).cleanTaskDescription('');
+            expect(result).toBe('');
+        });
+
+        it('should preserve recurrence rules and other text', () => {
+            const input = 'trocar óleo 0W-20 every 10k  🔁 every 6 months #luna [id::test]';
+            const result = (syncEngine as any).cleanTaskDescription(input);
+            expect(result).toBe('trocar óleo 0W-20 every 10k 🔁 every 6 months');
+        });
+
+        it('should preserve markdown links', () => {
+            const input = 'Task with [link](https://example.com) #sync [id::123]';
+            const result = (syncEngine as any).cleanTaskDescription(input);
+            expect(result).toBe('Task with [link](https://example.com)');
+        });
+
+        it('should preserve Obsidian metadata markers', () => {
+            const input = 'Task %%[some_id:: value]%% #sync [id::123]';
+            const result = (syncEngine as any).cleanTaskDescription(input);
+            expect(result).toBe('Task %%[some_id:: value]%%');
+        });
+    });
+
+    describe('Tag cleaning (bd-1)', () => {
+        it('should remove # prefix from tags', () => {
+            const tags = ['#sync', '#work', '#urgent'];
+            const result = (syncEngine as any).cleanTags(tags);
+            expect(result).toEqual(['sync', 'work', 'urgent']);
+        });
+
+        it('should handle tags without # prefix', () => {
+            const tags = ['sync', 'work'];
+            const result = (syncEngine as any).cleanTags(tags);
+            expect(result).toEqual(['sync', 'work']);
+        });
+
+        it('should handle mixed tags (with and without #)', () => {
+            const tags = ['#sync', 'work', '#urgent'];
+            const result = (syncEngine as any).cleanTags(tags);
+            expect(result).toEqual(['sync', 'work', 'urgent']);
+        });
+
+        it('should handle empty array', () => {
+            const result = (syncEngine as any).cleanTags([]);
+            expect(result).toEqual([]);
+        });
+
+        it('should preserve tag names with hyphens and underscores', () => {
+            const tags = ['#my-tag', '#another_tag'];
+            const result = (syncEngine as any).cleanTags(tags);
+            expect(result).toEqual(['my-tag', 'another_tag']);
+        });
+    });
+
     describe('Task markdown creation', () => {
         it('should create markdown with TODO status', () => {
             const task = {

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -218,7 +218,7 @@ export class SyncEngine {
      */
     private convertToObsidianTaskFormat(task: any): any {
         return {
-            description: task.description,
+            description: this.cleanTaskDescription(task.description),
             status: task.isDone ? 'DONE' : 'TODO',
             dueDate: task.dueDate ? task.dueDate.format('YYYY-MM-DD') : null,
             scheduledDate: task.scheduledDate ? task.scheduledDate.format('YYYY-MM-DD') : null,
@@ -226,8 +226,39 @@ export class SyncEngine {
             completedDate: task.doneDate ? task.doneDate.format('YYYY-MM-DD') : null,
             priority: this.mapPriority(task.priority),
             recurrenceRule: task.recurrence ? task.recurrence.toText() : '',
-            tags: task.tags || []
+            tags: this.cleanTags(task.tags || [])
         };
+    }
+
+    /**
+     * Clean task description by removing metadata that belongs in other fields
+     *
+     * Note: obsidian-tasks already parses out date emojis (⏳, 📅, ✅) from the description,
+     * so we only need to remove:
+     * - bd-2: Tags (#tag) - already in task.tags array
+     * - bd-4: Task ID ([id::xxx]) - internal Obsidian metadata
+     */
+    private cleanTaskDescription(description: string): string {
+        let cleaned = description;
+
+        // bd-4: Remove [id::xxx] pattern
+        cleaned = cleaned.replace(/\[id::[^\]]+\]/g, '');
+
+        // bd-2: Remove hashtags (but not # followed by numbers like #42)
+        cleaned = cleaned.replace(/#[a-zA-Z][\w-]*/g, '');
+
+        // Clean up extra whitespace
+        cleaned = cleaned.replace(/\s+/g, ' ').trim();
+
+        return cleaned;
+    }
+
+    /**
+     * Clean tags by removing # prefix
+     * Fixes bd-1: VTODO CATEGORIES should not include # character
+     */
+    private cleanTags(tags: string[]): string[] {
+        return tags.map(tag => tag.replace(/^#/, ''));
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes bd-1, bd-2, bd-3, bd-4: VTODO description cleaning

### Problem
- Raw task descriptions sent to CalDAV included all Obsidian metadata
- Tags (`#sync`), date emojis (`⏳ 2025-11-15`), and IDs (`[id::xxx]`) appeared in VTODO SUMMARY
- When syncing back from CalDAV, descriptions became corrupted/duplicated
- Example: `"Buy groceries"` → `"Buy groceries #sync [id::test-001] #sync [id::test-001]"`

### Key Discovery 🎉

**Obsidian-tasks already parses date emojis OUT of `task.description`!**

Looking at a real task object from obsidian-tasks:
```javascript
description: "trocar óleo 0W-20 every 10k  🔁 every 6 months #luna  [link](...) #ticktick"
originalMarkdown: "- [x] trocar óleo... #luna #ticktick 📅 2024-09-28 ✅ 2024-10-07"
dueDate: $ {...}      // ← Dates already parsed!
doneDate: $ {...}     // ← Into separate fields!
tags: ['#luna', '#ticktick']  // ← Tags already extracted!
```

So we only need to clean **tags** and **[id::xxx]** from the description - dates are already handled!

### Solution

**Added `cleanTaskDescription()`:**
- bd-4: Removes `[id::xxx]` pattern (internal Obsidian metadata)
- bd-2: Removes hashtags (but preserves `#42` style references)
- bd-3: ~~No regex needed!~~ Obsidian-tasks already handles date parsing
- Cleans up extra whitespace

**Added `cleanTags()`:**
- bd-1: Strips `#` prefix from tags for VTODO CATEGORIES field

### Before/After

**Before (broken):**
```
Obsidian task: "Buy groceries #sync 📅 2025-11-15 [id::test-001]"
↓
VTODO SUMMARY: "Buy groceries #sync [id::test-001]"  ← corrupted!
↓
Sync back: "Buy groceries #sync [id::test-001] #sync [id::test-001]"  ← doubled!
```

**After (fixed):**
```
Obsidian task: "Buy groceries #sync 📅 2025-11-15 [id::test-001]"
↓
task.description (from obsidian-tasks): "Buy groceries #sync [id::test-001]"  ← dates already removed!
↓
After cleanTaskDescription(): "Buy groceries"  ← clean!
↓
VTODO SUMMARY: "Buy groceries"
VTODO CATEGORIES: "sync" (not "#sync")
VTODO DUE: 2025-11-15  ← dates in proper fields
```

### Implementation

Simple regex cleaning (no complex emoji Unicode ranges needed):

```typescript
private cleanTaskDescription(description: string): string {
    let cleaned = description;
    
    // Remove [id::xxx] pattern
    cleaned = cleaned.replace(/\[id::[^\]]+\]/g, '');
    
    // Remove hashtags (but not # followed by numbers like #42)
    cleaned = cleaned.replace(/#[a-zA-Z][\w-]*/g, '');
    
    // Clean up extra whitespace
    cleaned = cleaned.replace(/\s+/g, ' ').trim();
    
    return cleaned;
}

private cleanTags(tags: string[]): string[] {
    return tags.map(tag => tag.replace(/^#/, ''));
}
```

### Testing

**Added 14 comprehensive tests:**
- ✅ Remove [id::xxx] from description
- ✅ Remove hashtags from description
- ✅ Preserve #42 style references
- ✅ Preserve recurrence rules (`🔁 every 6 months`)
- ✅ Preserve markdown links
- ✅ Preserve Obsidian metadata (`%%[...]%%`)
- ✅ Handle empty/whitespace-only descriptions
- ✅ Remove # prefix from tags

**All 117 tests pass!**

### Impact

This fix unblocks **bd-7** (CalDAV updates) which was failing Test 1 with corrupted descriptions.

Now syncing works cleanly:
1. Obsidian → CalDAV: Clean description, proper fields
2. CalDAV → Obsidian: No corruption, no duplication

### Files Changed
- `src/sync/syncEngine.ts` - Added cleaning methods, updated `convertToObsidianTaskFormat()`
- `src/sync/syncEngine.test.ts` - Added 14 tests for cleaning logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)