### PR TITLE
feat: E2E testing infrastructure with local Radicale CalDAV server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  radicale:
+    image: tomsquest/docker-radicale
+    ports:
+      - "5232:5232"
+    environment:
+      # Disable authentication for testing
+      RADICALE_AUTH__TYPE: none
+    tmpfs:
+      - /data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5232/.web/"]
+      interval: 2s
+      timeout: 5s
+      retries: 10

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test/e2e'],
+  testMatch: ['**/*.e2e.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  },
+  testTimeout: 30000,
+  moduleNameMapper: {
+    '^obsidian$': '<rootDir>/test/e2e/__mocks__/obsidian.ts'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"test": "jest",
 		"test:watch": "jest --watch",
 		"test:coverage": "jest --coverage",
+		"test:e2e": "docker compose up -d --wait && jest --config jest.e2e.config.js",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [],

--- a/src/caldav/httpClient.ts
+++ b/src/caldav/httpClient.ts
@@ -1,0 +1,40 @@
+import { requestUrl } from 'obsidian';
+
+export interface HttpResponse {
+  status: number;
+  text: string;
+  headers: Record<string, string>;
+}
+
+export interface HttpRequest {
+  url: string;
+  method: string;
+  headers?: Record<string, string>;
+  body?: string;
+  throw?: boolean;
+}
+
+export interface HttpClient {
+  request(params: HttpRequest): Promise<HttpResponse>;
+}
+
+/**
+ * Default HttpClient that delegates to Obsidian's requestUrl.
+ * Used in production; tests and E2E can substitute a different implementation.
+ */
+export class ObsidianHttpClient implements HttpClient {
+  async request(params: HttpRequest): Promise<HttpResponse> {
+    const response = await requestUrl({
+      url: params.url,
+      method: params.method,
+      headers: params.headers,
+      body: params.body,
+      throw: params.throw,
+    });
+    return {
+      status: response.status,
+      text: response.text,
+      headers: response.headers,
+    };
+  }
+}

--- a/test/e2e/__mocks__/obsidian.ts
+++ b/test/e2e/__mocks__/obsidian.ts
@@ -1,0 +1,8 @@
+/**
+ * Minimal obsidian stub for E2E tests.
+ * E2E tests use FetchHttpClient so should never touch Obsidian APIs.
+ * If this gets called, something is wrong.
+ */
+export const requestUrl = () => {
+  throw new Error('requestUrl should not be called in E2E tests — use FetchHttpClient');
+};

--- a/test/e2e/caldavClient.e2e.test.ts
+++ b/test/e2e/caldavClient.e2e.test.ts
@@ -1,0 +1,250 @@
+import { CalDAVClientDirect } from '../../src/caldav/calDAVClientDirect';
+import { VTODOMapper } from '../../src/caldav/vtodoMapper';
+import { FetchHttpClient } from '../helpers/fetchHttpClient';
+import { RADICALE, ensureCalendarExists, cleanCalendar } from '../helpers/radicaleSetup';
+
+/**
+ * End-to-end tests against a real Radicale CalDAV server.
+ *
+ * Prerequisites:
+ *   docker compose up -d --wait
+ *
+ * Run:
+ *   npm run test:e2e
+ */
+
+const httpClient = new FetchHttpClient();
+const mapper = new VTODOMapper();
+
+function makeClient(): CalDAVClientDirect {
+  return new CalDAVClientDirect(
+    {
+      serverUrl: RADICALE.baseUrl,
+      username: RADICALE.username,
+      password: RADICALE.password,
+      calendarName: RADICALE.calendarName,
+      syncTag: '',
+      syncInterval: 5,
+      newTasksDestination: 'Inbox.md',
+      requireManualConflictResolution: false,
+      autoResolveObsidianWins: false,
+      syncCompletedTasks: false,
+      deleteBehavior: 'ask',
+    },
+    httpClient,
+  );
+}
+
+function buildVTODO(uid: string, summary: string, extra: string[] = []): string {
+  const hasStatus = extra.some(l => l.startsWith('STATUS:'));
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//E2E Test//EN',
+    'BEGIN:VTODO',
+    `UID:${uid}`,
+    `DTSTAMP:20250101T000000Z`,
+    `SUMMARY:${summary}`,
+    ...(hasStatus ? [] : ['STATUS:NEEDS-ACTION']),
+    ...extra,
+    'END:VTODO',
+    'END:VCALENDAR',
+  ];
+  return lines.join('\r\n');
+}
+
+beforeAll(async () => {
+  await ensureCalendarExists();
+});
+
+beforeEach(async () => {
+  await cleanCalendar();
+});
+
+describe('Calendar discovery', () => {
+  it('should connect and find the test calendar', async () => {
+    const client = makeClient();
+    await client.connect();
+    expect(client.isConnected()).toBe(true);
+  });
+
+  it('should fail when calendar name does not exist', async () => {
+    const client = new CalDAVClientDirect(
+      {
+        serverUrl: RADICALE.baseUrl,
+        username: RADICALE.username,
+        password: RADICALE.password,
+        calendarName: 'nonexistent-calendar',
+        syncTag: '',
+        syncInterval: 5,
+        newTasksDestination: 'Inbox.md',
+        requireManualConflictResolution: false,
+        autoResolveObsidianWins: false,
+        syncCompletedTasks: false,
+        deleteBehavior: 'ask',
+      },
+      httpClient,
+    );
+    await expect(client.connect()).rejects.toThrow(/not found/i);
+  });
+});
+
+describe('VTODO CRUD round-trip', () => {
+  it('should create, fetch, update, and delete a VTODO', async () => {
+    const client = makeClient();
+    await client.connect();
+
+    const uid = `e2e-crud-${Date.now()}`;
+    const vtodo = buildVTODO(uid, 'Buy groceries');
+
+    // Create
+    await client.createVTODO(vtodo, uid);
+
+    // Fetch — should find exactly one
+    let todos = await client.fetchVTODOs();
+    expect(todos.length).toBe(1);
+
+    const fetched = todos[0];
+    const task = mapper.vtodoToTask(fetched);
+    expect(task.description).toBe('Buy groceries');
+    expect(task.status).toBe('TODO');
+
+    // Update — mark completed
+    const updated = buildVTODO(uid, 'Buy groceries', [
+      'STATUS:COMPLETED',
+      'COMPLETED:20250601T120000Z',
+      'PERCENT-COMPLETE:100',
+    ]);
+    await client.updateVTODO(fetched, updated);
+
+    // Fetch again — verify update
+    todos = await client.fetchVTODOs();
+    expect(todos.length).toBe(1);
+    const updatedTask = mapper.vtodoToTask(todos[0]);
+    expect(updatedTask.status).toBe('DONE');
+
+    // Delete
+    await client.deleteVTODO(todos[0]);
+
+    // Fetch again — should be empty
+    todos = await client.fetchVTODOs();
+    expect(todos.length).toBe(0);
+  });
+});
+
+describe('VTODO with folded lines', () => {
+  it('should handle a long summary that the server may fold', async () => {
+    const client = makeClient();
+    await client.connect();
+
+    const uid = `e2e-fold-${Date.now()}`;
+    const longSummary =
+      'This is a very long task description that exceeds seventy-five octets and should be folded by the server according to RFC 5545 line folding rules';
+
+    const vtodo = buildVTODO(uid, longSummary);
+    await client.createVTODO(vtodo, uid);
+
+    const todos = await client.fetchVTODOs();
+    expect(todos.length).toBe(1);
+    const task = mapper.vtodoToTask(todos[0]);
+    expect(task.description).toBe(longSummary);
+  });
+});
+
+describe('VTODO with VTIMEZONE and TZID dates', () => {
+  it('should round-trip a VTODO that uses TZID parameters', async () => {
+    const client = makeClient();
+    await client.connect();
+
+    const uid = `e2e-tz-${Date.now()}`;
+    const vtodoData = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//E2E Test//EN',
+      'BEGIN:VTIMEZONE',
+      'TZID:America/New_York',
+      'BEGIN:STANDARD',
+      'DTSTART:19701101T020000',
+      'RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=11',
+      'TZOFFSETFROM:-0400',
+      'TZOFFSETTO:-0500',
+      'TZNAME:EST',
+      'END:STANDARD',
+      'BEGIN:DAYLIGHT',
+      'DTSTART:19700308T020000',
+      'RRULE:FREQ=YEARLY;BYDAY=2SU;BYMONTH=3',
+      'TZOFFSETFROM:-0500',
+      'TZOFFSETTO:-0400',
+      'TZNAME:EDT',
+      'END:DAYLIGHT',
+      'END:VTIMEZONE',
+      'BEGIN:VTODO',
+      `UID:${uid}`,
+      'DTSTAMP:20250601T100000Z',
+      'SUMMARY:Meeting prep',
+      'STATUS:NEEDS-ACTION',
+      'DTSTART;TZID=America/New_York:20250615T090000',
+      'DUE;TZID=America/New_York:20250615T170000',
+      'END:VTODO',
+      'END:VCALENDAR',
+    ].join('\r\n');
+
+    await client.createVTODO(vtodoData, uid);
+
+    const todos = await client.fetchVTODOs();
+    expect(todos.length).toBe(1);
+
+    const task = mapper.vtodoToTask(todos[0]);
+    expect(task.description).toBe('Meeting prep');
+    expect(task.dueDate).toBe('2025-06-15');
+    expect(task.scheduledDate).toBe('2025-06-15');
+  });
+});
+
+describe('VTODO with recurrence', () => {
+  it('should preserve RRULE through a round-trip', async () => {
+    const client = makeClient();
+    await client.connect();
+
+    const uid = `e2e-rrule-${Date.now()}`;
+    const vtodo = buildVTODO(uid, 'Daily standup', [
+      'RRULE:FREQ=DAILY;COUNT=30',
+      'DUE;VALUE=DATE:20250701',
+    ]);
+
+    await client.createVTODO(vtodo, uid);
+
+    const todos = await client.fetchVTODOs();
+    expect(todos.length).toBe(1);
+
+    const task = mapper.vtodoToTask(todos[0]);
+    expect(task.description).toBe('Daily standup');
+    expect(task.recurrenceRule).toBe('FREQ=DAILY;COUNT=30');
+    expect(task.dueDate).toBe('2025-07-01');
+  });
+});
+
+describe('Multiple VTODOs', () => {
+  it('should handle multiple VTODOs in the same calendar', async () => {
+    const client = makeClient();
+    await client.connect();
+
+    const uids = [
+      `e2e-multi-1-${Date.now()}`,
+      `e2e-multi-2-${Date.now()}`,
+      `e2e-multi-3-${Date.now()}`,
+    ];
+
+    for (const uid of uids) {
+      await client.createVTODO(buildVTODO(uid, `Task ${uid}`), uid);
+    }
+
+    const todos = await client.fetchVTODOs();
+    expect(todos.length).toBe(3);
+
+    // Delete one
+    await client.deleteVTODO(todos[0]);
+    const remaining = await client.fetchVTODOs();
+    expect(remaining.length).toBe(2);
+  });
+});

--- a/test/helpers/fetchHttpClient.ts
+++ b/test/helpers/fetchHttpClient.ts
@@ -1,0 +1,23 @@
+import { HttpClient, HttpRequest, HttpResponse } from '../../src/caldav/httpClient';
+
+/**
+ * HttpClient backed by Node.js native fetch.
+ * Used in E2E tests against a real CalDAV server (Radicale).
+ */
+export class FetchHttpClient implements HttpClient {
+  async request(params: HttpRequest): Promise<HttpResponse> {
+    const resp = await fetch(params.url, {
+      method: params.method,
+      headers: params.headers,
+      body: params.body,
+    });
+
+    const text = await resp.text();
+    const headers: Record<string, string> = {};
+    resp.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+
+    return { status: resp.status, text, headers };
+  }
+}

--- a/test/helpers/radicaleSetup.ts
+++ b/test/helpers/radicaleSetup.ts
@@ -1,0 +1,98 @@
+import { FetchHttpClient } from './fetchHttpClient';
+
+export const RADICALE = {
+  baseUrl: 'http://localhost:5232',
+  username: 'testuser',
+  password: 'testpass',
+  calendarName: 'e2e-tasks',
+  get userPath() {
+    return `/${this.username}/`;
+  },
+  get calendarPath() {
+    return `/${this.username}/${this.calendarName}/`;
+  },
+  get calendarUrl() {
+    return `${this.baseUrl}${this.calendarPath}`;
+  },
+} as const;
+
+const http = new FetchHttpClient();
+
+/**
+ * Ensure the parent user collection exists (Radicale requires it).
+ */
+async function ensureUserCollection(): Promise<void> {
+  const url = `${RADICALE.baseUrl}${RADICALE.userPath}`;
+  const check = await http.request({
+    url,
+    method: 'PROPFIND',
+    headers: { 'Depth': '0' },
+  });
+  if (check.status === 207) return;
+
+  await http.request({ url, method: 'MKCOL', headers: {} });
+}
+
+/**
+ * Create the test calendar via MKCALENDAR if it doesn't already exist.
+ */
+export async function ensureCalendarExists(): Promise<void> {
+  await ensureUserCollection();
+
+  const url = RADICALE.calendarUrl;
+
+  // Check if calendar already exists
+  const check = await http.request({
+    url,
+    method: 'PROPFIND',
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Depth': '0',
+    },
+    body: `<?xml version="1.0" encoding="UTF-8"?>
+<d:propfind xmlns:d="DAV:">
+  <d:prop><d:resourcetype /></d:prop>
+</d:propfind>`,
+  });
+
+  if (check.status === 207) {
+    return; // already exists
+  }
+
+  // Create the calendar
+  const resp = await http.request({
+    url,
+    method: 'MKCALENDAR',
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+    body: `<?xml version="1.0" encoding="UTF-8"?>
+<c:mkcalendar xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:set>
+    <d:prop>
+      <d:displayname>${RADICALE.calendarName}</d:displayname>
+      <c:supported-calendar-component-set>
+        <c:comp name="VTODO" />
+      </c:supported-calendar-component-set>
+    </d:prop>
+  </d:set>
+</c:mkcalendar>`,
+  });
+
+  if (resp.status !== 201 && resp.status !== 207) {
+    throw new Error(`MKCALENDAR failed: ${resp.status} ${resp.text}`);
+  }
+}
+
+/**
+ * Delete the test calendar and recreate it empty.
+ */
+export async function cleanCalendar(): Promise<void> {
+  await http.request({
+    url: RADICALE.calendarUrl,
+    method: 'DELETE',
+    headers: {},
+  });
+
+  await ensureCalendarExists();
+}


### PR DESCRIPTION
## Summary
- Add `HttpClient` abstraction layer so `CalDAVClientDirect` can use either Obsidian's `requestUrl` (production) or Node.js `fetch` (E2E tests)
- Set up Docker Compose with Radicale CalDAV server for local E2E testing
- Add 7 E2E tests: discovery, CRUD round-trip, line folding, VTIMEZONE/TZID dates, recurrence, multi-VTODO
- Fix namespace-agnostic XML parsing (handles Radicale's unprefixed DAV elements and uppercase `C:` CalDAV prefix)
- Update CLAUDE.md with testing guidelines: discover issues with E2E, lock down with unit tests

## Test plan
- [x] `npm test` — 177 unit tests pass (no regression)
- [x] `npm run test:e2e` — 7 E2E tests pass against real Radicale
- [x] Container stays running between test runs (`docker compose up -d`)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)