### PR TITLE
feat: round-trip VTODO DESCRIPTION as indented bullets

### DIFF
--- a/src/caldav/vtodoMapper.test.ts
+++ b/src/caldav/vtodoMapper.test.ts
@@ -18,7 +18,8 @@ describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       const vtodo = mapper.taskToVTODO(task, 'test-uid-123');
@@ -40,7 +41,8 @@ describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       const vtodo = mapper.taskToVTODO(task, 'test-uid');
@@ -58,7 +60,8 @@ describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       const vtodo = mapper.taskToVTODO(task, 'test-uid');
@@ -84,7 +87,8 @@ describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
           completedDate: null,
           priority: 'none',
           recurrenceRule: '',
-          tags: []
+          tags: [],
+          notes: '',
         };
 
         const result = mapper.taskToVTODO(task, 'test-uid');
@@ -112,7 +116,8 @@ describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
           completedDate: null,
           priority: obsidian,
           recurrenceRule: '',
-          tags: []
+          tags: [],
+          notes: '',
         };
 
         const result = mapper.taskToVTODO(task, 'test-uid');
@@ -130,7 +135,8 @@ describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
         completedDate: '2025-01-05T10:30:00Z',
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       const vtodo = mapper.taskToVTODO(task, 'test-uid');
@@ -149,7 +155,8 @@ describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: ['work', 'urgent', 'project-a']
+        tags: ['work', 'urgent', 'project-a'],
+        notes: '',
       };
 
       const vtodo = mapper.taskToVTODO(task, 'test-uid');
@@ -167,7 +174,8 @@ describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       const vtodo = mapper.taskToVTODO(task, 'test-uid');
@@ -185,7 +193,8 @@ describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
         completedDate: null,
         priority: 'none',
         recurrenceRule: 'FREQ=DAILY;COUNT=10',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       const vtodo = mapper.taskToVTODO(task, 'test-uid');
@@ -436,7 +445,8 @@ END:VTODO`;
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       // Escape: task to VTODO
@@ -470,7 +480,8 @@ END:VTODO`;
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       // Round-trip: task → VTODO → task
@@ -498,7 +509,8 @@ END:VTODO`;
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       // First sync: task → VTODO → task
@@ -531,7 +543,8 @@ END:VTODO`;
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: ['home,work', 'urgent']
+        tags: ['home,work', 'urgent'],
+        notes: '',
       };
 
       // Escape: task to VTODO
@@ -557,6 +570,189 @@ END:VTODO`;
     });
   });
 
+  describe('DESCRIPTION (notes) handling', () => {
+    it('should extract DESCRIPTION from VTODO', () => {
+      const vtodoData = `BEGIN:VTODO
+UID:desc-test
+SUMMARY:Task with notes
+DESCRIPTION:Remember to check the farmers market
+STATUS:NEEDS-ACTION
+END:VTODO`;
+
+      const vtodo: CalendarObject = {
+        data: vtodoData,
+        etag: 'test-etag',
+        url: 'http://example.com/test.ics'
+      };
+
+      const task = mapper.vtodoToTask(vtodo);
+      expect(task.notes).toBe('Remember to check the farmers market');
+    });
+
+    it('should return empty string when DESCRIPTION is missing', () => {
+      const vtodoData = `BEGIN:VTODO
+UID:no-desc
+SUMMARY:Task without notes
+STATUS:NEEDS-ACTION
+END:VTODO`;
+
+      const vtodo: CalendarObject = {
+        data: vtodoData,
+        etag: 'test-etag',
+        url: 'http://example.com/test.ics'
+      };
+
+      const task = mapper.vtodoToTask(vtodo);
+      expect(task.notes).toBe('');
+    });
+
+    it('should handle multi-line DESCRIPTION with escaped newlines', () => {
+      const vtodoData = `BEGIN:VTODO
+UID:multiline-desc
+SUMMARY:Task
+DESCRIPTION:Line one\\nLine two\\nLine three
+STATUS:NEEDS-ACTION
+END:VTODO`;
+
+      const vtodo: CalendarObject = {
+        data: vtodoData,
+        etag: 'test-etag',
+        url: 'http://example.com/test.ics'
+      };
+
+      const task = mapper.vtodoToTask(vtodo);
+      expect(task.notes).toBe('Line one\nLine two\nLine three');
+    });
+
+    it('should handle DESCRIPTION with colons', () => {
+      const vtodoData = `BEGIN:VTODO
+UID:colon-desc
+SUMMARY:Task
+DESCRIPTION:Meeting at 10:30 with team: discuss roadmap
+STATUS:NEEDS-ACTION
+END:VTODO`;
+
+      const vtodo: CalendarObject = {
+        data: vtodoData,
+        etag: 'test-etag',
+        url: 'http://example.com/test.ics'
+      };
+
+      const task = mapper.vtodoToTask(vtodo);
+      expect(task.notes).toBe('Meeting at 10:30 with team: discuss roadmap');
+    });
+
+    it('should handle folded DESCRIPTION lines', () => {
+      const vtodoData = `BEGIN:VTODO\r\nUID:folded-desc\r\nSUMMARY:Task\r\nDESCRIPTION:A very long description that has been \r\n folded by the server into multiple lines\r\nSTATUS:NEEDS-ACTION\r\nEND:VTODO`;
+
+      const vtodo: CalendarObject = {
+        data: vtodoData,
+        etag: 'test-etag',
+        url: 'http://example.com/test.ics'
+      };
+
+      const task = mapper.vtodoToTask(vtodo);
+      expect(task.notes).toBe('A very long description that has been folded by the server into multiple lines');
+    });
+
+    it('should write DESCRIPTION to VTODO when notes is non-empty', () => {
+      const task: ObsidianTask = {
+        description: 'Task',
+        status: 'TODO',
+        dueDate: null,
+        scheduledDate: null,
+        startDate: null,
+        completedDate: null,
+        priority: 'none',
+        recurrenceRule: '',
+        tags: [],
+        notes: 'Remember to bring supplies',
+      };
+
+      const vtodo = mapper.taskToVTODO(task, 'test-uid');
+      expect(vtodo).toContain('DESCRIPTION:Remember to bring supplies');
+    });
+
+    it('should not write DESCRIPTION when notes is empty', () => {
+      const task: ObsidianTask = {
+        description: 'Task',
+        status: 'TODO',
+        dueDate: null,
+        scheduledDate: null,
+        startDate: null,
+        completedDate: null,
+        priority: 'none',
+        recurrenceRule: '',
+        tags: [],
+        notes: '',
+      };
+
+      const vtodo = mapper.taskToVTODO(task, 'test-uid');
+      expect(vtodo).not.toContain('DESCRIPTION');
+    });
+
+    it('should escape special characters in DESCRIPTION', () => {
+      const task: ObsidianTask = {
+        description: 'Task',
+        status: 'TODO',
+        dueDate: null,
+        scheduledDate: null,
+        startDate: null,
+        completedDate: null,
+        priority: 'none',
+        recurrenceRule: '',
+        tags: [],
+        notes: 'Line 1\nLine 2; with semicolons, commas',
+      };
+
+      const vtodo = mapper.taskToVTODO(task, 'test-uid');
+      expect(vtodo).toContain('DESCRIPTION:Line 1\\nLine 2\\; with semicolons\\, commas');
+    });
+
+    it('should round-trip DESCRIPTION with special characters', () => {
+      const task: ObsidianTask = {
+        description: 'Task',
+        status: 'TODO',
+        dueDate: null,
+        scheduledDate: null,
+        startDate: null,
+        completedDate: null,
+        priority: 'none',
+        recurrenceRule: '',
+        tags: [],
+        notes: 'Meeting at 10:30\nBring items: laptop, notebook\nNote; important',
+      };
+
+      const vtodo = mapper.taskToVTODO(task, 'test-uid');
+      const calObj: CalendarObject = { data: vtodo, etag: 'e1', url: 'http://test' };
+      const parsed = mapper.vtodoToTask(calObj);
+
+      expect(parsed.notes).toBe('Meeting at 10:30\nBring items: laptop, notebook\nNote; important');
+    });
+
+    it('should not extract DESCRIPTION from VALARM component', () => {
+      const vtodoData = `BEGIN:VTODO
+UID:valarm-desc
+SUMMARY:Task
+DESCRIPTION:Real task notes
+BEGIN:VALARM
+DESCRIPTION:Reminder
+TRIGGER:-PT15M
+END:VALARM
+STATUS:NEEDS-ACTION
+END:VTODO`;
+
+      const vtodo: CalendarObject = {
+        data: vtodoData,
+        etag: 'test-etag',
+        url: 'http://example.com/test.ics'
+      };
+
+      const task = mapper.vtodoToTask(vtodo);
+      expect(task.notes).toBe('Real task notes');
+    });
+  });
+
   describe('Date timezone handling', () => {
     it('should preserve date-only strings without timezone conversion', () => {
       // When we have a date string like "2026-02-11", it should remain "2026-02-11"
@@ -570,7 +766,8 @@ END:VTODO`;
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       const vtodo = mapper.taskToVTODO(task, 'test-uid');
@@ -591,7 +788,8 @@ END:VTODO`;
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       // Convert to VTODO and back
@@ -619,7 +817,8 @@ END:VTODO`;
         completedDate: null,
         priority: 'none',
         recurrenceRule: '',
-        tags: []
+        tags: [],
+        notes: '',
       };
 
       // Sync 1: task → VTODO → task
@@ -778,8 +977,8 @@ END:VTODO`;
         'SUMMARY:Weekly grocery shopping with a very long description',
         ' that continues on the next line and needs to be',
         ' unfolded properly',
-        'DESCRIPTION:Buy the following items from the store: bread\\,',
-        ' milk\\, eggs\\, cheese\\, and other essentials for',
+        'DESCRIPTION:Buy the following items from the store: bread\\, ',
+        ' milk\\, eggs\\, cheese\\, and other essentials for ',
         ' the week ahead.',
         'DUE;TZID=Pacific/Auckland:20260214T060001',
         'DTSTART;TZID=Pacific/Auckland:20260214T000000',
@@ -815,6 +1014,13 @@ END:VTODO`;
       expect(task.priority).toBe('high');
       expect(task.tags).toEqual(['groceries', 'weekly']);
       expect(task.recurrenceRule).toBe('FREQ=WEEKLY;BYDAY=SA');
+
+      // Folded DESCRIPTION should be unfolded and unescaped
+      expect(task.notes).toBe(
+        'Buy the following items from the store: bread,' +
+        ' milk, eggs, cheese, and other essentials for' +
+        ' the week ahead.'
+      );
 
       // UID extraction should also handle unfolding
       const uid = mapper.extractUID(vtodoData);

--- a/src/storage/syncStorage.test.ts
+++ b/src/storage/syncStorage.test.ts
@@ -14,6 +14,7 @@ function makeCommonTask(overrides: Partial<CommonTask> = {}): CommonTask {
     priority: 'none',
     tags: [],
     recurrenceRule: '',
+    notes: '',
     ...overrides,
   };
 }
@@ -475,6 +476,35 @@ describe('SyncStorage', () => {
       await storage.initialize();
 
       expect(storage.getBaseline()).toEqual(baseline);
+    });
+  });
+
+  describe('baseline migration', () => {
+    it('should default missing notes field to empty string when loading baseline', async () => {
+      // Simulate a baseline saved by older code without the `notes` field
+      const oldBaseline = [
+        {
+          uid: 'old-task',
+          title: 'Task from old version',
+          status: 'TODO',
+          dueDate: null,
+          startDate: null,
+          scheduledDate: null,
+          completedDate: null,
+          priority: 'none',
+          tags: [],
+          recurrenceRule: '',
+          // No `notes` field
+        },
+      ];
+
+      setupExistingAdapter(adapter, { baseline: oldBaseline as any });
+
+      await storage.initialize();
+
+      const baseline = storage.getBaseline();
+      expect(baseline).toHaveLength(1);
+      expect(baseline[0].notes).toBe('');
     });
   });
 

--- a/src/storage/syncStorage.ts
+++ b/src/storage/syncStorage.ts
@@ -322,7 +322,9 @@ export class SyncStorage {
         return [];
       }
       const content = await adapter.read(this.baselinePath);
-      return JSON.parse(content);
+      const tasks: CommonTask[] = JSON.parse(content);
+      // Migrate old baselines: default missing `notes` to ''
+      return tasks.map(t => ({ ...t, notes: t.notes ?? '' }));
     } catch (error) {
       console.error('Failed to load baseline:', error);
       return [];

--- a/src/sync/caldavAdapter.test.ts
+++ b/src/sync/caldavAdapter.test.ts
@@ -46,6 +46,13 @@ describe('CalDAVAdapter', () => {
       expect(task.completedDate).toBeNull();
       expect(task.tags).toEqual([]);
       expect(task.recurrenceRule).toBe('');
+      expect(task.notes).toBe('');
+    });
+
+    it('should extract notes from DESCRIPTION', () => {
+      const vtodo = makeCalObj('caldav-notes', 'Task with notes', ['DESCRIPTION:Remember to check']);
+      const task = adapter.toCommonTask(vtodo, 'my-id');
+      expect(task.notes).toBe('Remember to check');
     });
 
     it('should map VTODO status correctly', () => {
@@ -142,6 +149,7 @@ describe('CalDAVAdapter', () => {
         priority: 'high' as const,
         tags: ['sync', 'work'],
         recurrenceRule: '',
+        notes: '',
       };
 
       const vtodo = adapter.fromCommonTask(task, 'caldav-uid-001');
@@ -153,6 +161,44 @@ describe('CalDAVAdapter', () => {
       expect(vtodo).toContain('DTSTART;VALUE=DATE:20250110');
       expect(vtodo).toContain('PRIORITY:3');
       expect(vtodo).toContain('CATEGORIES:sync,work');
+    });
+
+    it('should include DESCRIPTION when notes is non-empty', () => {
+      const task = {
+        uid: 'notes-id',
+        title: 'Task with notes',
+        status: 'TODO' as const,
+        dueDate: null,
+        startDate: null,
+        scheduledDate: null,
+        completedDate: null,
+        priority: 'none' as const,
+        tags: [],
+        recurrenceRule: '',
+        notes: 'Remember to bring supplies',
+      };
+
+      const vtodo = adapter.fromCommonTask(task, 'caldav-notes');
+      expect(vtodo).toContain('DESCRIPTION:Remember to bring supplies');
+    });
+
+    it('should omit DESCRIPTION when notes is empty', () => {
+      const task = {
+        uid: 'no-notes',
+        title: 'Task without notes',
+        status: 'TODO' as const,
+        dueDate: null,
+        startDate: null,
+        scheduledDate: null,
+        completedDate: null,
+        priority: 'none' as const,
+        tags: [],
+        recurrenceRule: '',
+        notes: '',
+      };
+
+      const vtodo = adapter.fromCommonTask(task, 'caldav-no-notes');
+      expect(vtodo).not.toContain('DESCRIPTION');
     });
 
     it('should handle completed tasks', () => {
@@ -167,6 +213,7 @@ describe('CalDAVAdapter', () => {
         priority: 'none' as const,
         tags: [],
         recurrenceRule: '',
+        notes: '',
       };
 
       const vtodo = adapter.fromCommonTask(task, 'caldav-done');
@@ -197,6 +244,7 @@ describe('CalDAVAdapter', () => {
         priority: 'none' as const,
         tags: [],
         recurrenceRule: '',
+        notes: '',
       };
 
       await adapter.applyChanges(
@@ -228,6 +276,7 @@ describe('CalDAVAdapter', () => {
         priority: 'none' as const,
         tags: [],
         recurrenceRule: '',
+        notes: '',
       };
 
       await adapter.applyChanges(
@@ -262,6 +311,7 @@ describe('CalDAVAdapter', () => {
         priority: 'none' as const,
         tags: [],
         recurrenceRule: '',
+        notes: '',
       };
 
       await adapter.applyChanges(

--- a/src/sync/caldavAdapter.ts
+++ b/src/sync/caldavAdapter.ts
@@ -46,6 +46,7 @@ export class CalDAVAdapter {
       priority: parsed.priority as TaskPriority,
       tags: parsed.tags,
       recurrenceRule: parsed.recurrenceRule,
+      notes: parsed.notes,
     };
   }
 
@@ -63,6 +64,7 @@ export class CalDAVAdapter {
       priority: task.priority,
       tags: task.tags,
       recurrenceRule: task.recurrenceRule,
+      notes: task.notes,
     };
 
     return this.mapper.taskToVTODO(obsidianTask, caldavUID);

--- a/src/sync/diff.test.ts
+++ b/src/sync/diff.test.ts
@@ -13,6 +13,7 @@ function makeCommonTask(overrides: Partial<CommonTask> = {}): CommonTask {
     priority: 'none',
     tags: [],
     recurrenceRule: '',
+    notes: '',
     ...overrides,
   };
 }
@@ -63,6 +64,24 @@ describe('tasksEqual', () => {
   it('should handle null vs non-null dates', () => {
     const a = makeCommonTask({ dueDate: null });
     const b = makeCommonTask({ dueDate: '2025-01-15' });
+    expect(tasksEqual(a, b)).toBe(false);
+  });
+
+  it('should detect notes change', () => {
+    const a = makeCommonTask({ notes: 'Note A' });
+    const b = makeCommonTask({ notes: 'Note B' });
+    expect(tasksEqual(a, b)).toBe(false);
+  });
+
+  it('should treat empty notes as equal', () => {
+    const a = makeCommonTask({ notes: '' });
+    const b = makeCommonTask({ notes: '' });
+    expect(tasksEqual(a, b)).toBe(true);
+  });
+
+  it('should detect notes added where there were none', () => {
+    const a = makeCommonTask({ notes: '' });
+    const b = makeCommonTask({ notes: 'New note' });
     expect(tasksEqual(a, b)).toBe(false);
   });
 });

--- a/src/sync/diff.ts
+++ b/src/sync/diff.ts
@@ -13,6 +13,7 @@ export function tasksEqual(a: CommonTask, b: CommonTask): boolean {
     a.completedDate === b.completedDate &&
     a.priority === b.priority &&
     a.recurrenceRule === b.recurrenceRule &&
+    a.notes === b.notes &&
     a.tags.length === b.tags.length &&
     a.tags.every((tag, i) => tag === b.tags[i])
   );

--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -72,6 +72,7 @@ const mockEnsureTaskHasId = jest.fn().mockResolvedValue('mock-id');
 const mockFindTaskById = jest.fn().mockReturnValue(null);
 const mockCreateTask = jest.fn().mockResolvedValue(undefined);
 const mockUpdateTaskInVault = jest.fn().mockResolvedValue(undefined);
+const mockGetTaskId = jest.fn().mockImplementation((task: any) => task.id || null);
 
 jest.mock('../tasks/taskManager', () => ({
   TaskManager: jest.fn().mockImplementation(() => ({
@@ -81,6 +82,7 @@ jest.mock('../tasks/taskManager', () => ({
     findTaskById: mockFindTaskById,
     createTask: mockCreateTask,
     updateTaskInVault: mockUpdateTaskInVault,
+    getTaskId: mockGetTaskId,
   })),
 }));
 
@@ -140,6 +142,7 @@ describe('SyncEngine', () => {
     mockFindTaskById.mockReturnValue(null);
     mockCreateTask.mockResolvedValue(undefined);
     mockUpdateTaskInVault.mockResolvedValue(undefined);
+    mockGetTaskId.mockImplementation((task: any) => task.id || null);
     mockConnect.mockResolvedValue(undefined);
     mockFetchVTODOs.mockResolvedValue([]);
     mockCreateVTODO.mockResolvedValue(undefined);
@@ -309,6 +312,7 @@ describe('SyncEngine', () => {
         priority: 'none',
         tags: [],
         recurrenceRule: '',
+        notes: '',
       }]);
 
       const engine = new SyncEngine(new App(), makeSettings());
@@ -426,6 +430,7 @@ describe('SyncEngine', () => {
         priority: 'none' as const,
         tags: [] as string[],
         recurrenceRule: '',
+        notes: '',
       };
 
       const obsTask = makeObsidianTask({
@@ -468,6 +473,7 @@ describe('SyncEngine', () => {
         priority: 'none' as const,
         tags: [] as string[],
         recurrenceRule: '',
+        notes: '',
       };
 
       const obsTask = makeObsidianTask({
@@ -747,6 +753,7 @@ describe('SyncEngine', () => {
         priority: 'none' as const,
         tags: [] as string[],
         recurrenceRule: '',
+        notes: '',
       };
 
       // Obsidian still has the original

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -12,6 +12,7 @@ export interface CommonTask {
   priority: TaskPriority;
   tags: string[];               // without # prefix
   recurrenceRule: string;       // RRULE string or ''
+  notes: string;                // multi-line notes/body text, '' = no notes
 }
 
 export interface SyncChange {

--- a/src/tasks/taskManager.ts
+++ b/src/tasks/taskManager.ts
@@ -226,8 +226,19 @@ export class TaskManager {
             throw new Error(`Could not find task in file: ${originalMarkdown}`);
         }
 
-        // Update the line
-        lines[taskIndex] = newContent;
+        // Count indented note lines below the task
+        let noteLineCount = 0;
+        for (let i = taskIndex + 1; i < lines.length; i++) {
+            if (/^(?:\s{2,}|\t)- /.test(lines[i])) {
+                noteLineCount++;
+            } else {
+                break;
+            }
+        }
+
+        // Replace the task line + any note lines with new content
+        const newLines = newContent.split('\n');
+        lines.splice(taskIndex, 1 + noteLineCount, ...newLines);
 
         // Write back to file
         await this.app.vault.modify(file, lines.join('\n'));

--- a/test/e2e/syncRoundTrip.e2e.test.ts
+++ b/test/e2e/syncRoundTrip.e2e.test.ts
@@ -117,6 +117,7 @@ describe('Sync round-trip E2E', () => {
         priority: 'high',
         tags: ['sync'],
         recurrenceRule: '',
+        notes: '',
       },
     ];
 


### PR DESCRIPTION
## Summary

Closes #19

- Round-trip CalDAV VTODO `DESCRIPTION` property between CalDAV and Obsidian, where notes appear as indented bullet points below the task line
- Add `notes: string` field to `CommonTask` throughout the sync pipeline (diff engine, adapters, storage, sync engine)
- Extract/write DESCRIPTION in VTODOMapper using `extractRawProperty()` to avoid colon-splitting bugs, with proper iCalendar escaping
- Handle multi-line task blocks in TaskManager (replace task line + indented note lines as a unit)
- Migrate old baselines that lack the `notes` field

## Test plan

- [x] Unit tests pass (295 tests across 9 suites)
- [x] E2E tests pass against Radicale (22 tests across 3 suites, including 4 new DESCRIPTION round-trip tests)
- [x] Coverage thresholds met (sync/ 80%/80%, caldav/ 80%/70%, tasks/ 80%/80%)
- [x] TypeScript build passes (`npm run build`)
- [x] Manual: Verify indented bullets render correctly in Obsidian
- [x] Manual: Verify notes from Tasks.org/Thunderbird survive sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)