### PR TITLE
Verify completion date is preserved from CalDAV

### DIFF
--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -789,6 +789,63 @@ describe('SyncEngine', () => {
       // First arg should be the existing obsidian task
       expect(mockUpdateTaskInVault.mock.calls[0][0]).toBe(obsTask);
     });
+
+    it('should include completion date when CalDAV marks task as done', async () => {
+      // Baseline: task is TODO
+      const baseline = {
+        uid: '20250101-abc',
+        description: 'Task to complete',
+        status: 'TODO' as const,
+        dueDate: '2025-07-01',
+        startDate: null,
+        scheduledDate: null,
+        completedDate: null,
+        priority: 'none' as const,
+        tags: [] as string[],
+        recurrenceRule: '',
+        notes: '',
+      };
+
+      // Obsidian still has TODO
+      const obsTask = makeObsidianTask({
+        description: 'Task to complete',
+        id: '20250101-abc',
+        tags: ['#sync'],
+        originalMarkdown: '- [ ] Task to complete 📅 2025-07-01 🆔 20250101-abc #sync',
+      });
+
+      // CalDAV has completed the task with a completion date
+      const vtodo = makeCalObj('caldav-abc', 'Task to complete', [
+        'DUE;VALUE=DATE:20250701',
+        'STATUS:COMPLETED',
+        'COMPLETED:20250715T140000Z',
+        'PERCENT-COMPLETE:100',
+      ]);
+
+      mockGetAllTasks.mockReturnValue([obsTask]);
+      mockFetchVTODOs.mockResolvedValue([vtodo]);
+      mockGetBaseline.mockReturnValue([baseline]);
+      mockGetMapping.mockReturnValue({
+        tasks: { '20250101-abc': { caldavUID: 'caldav-abc', sourceFile: 'Tasks.md', lastSyncedObsidian: '', lastSyncedCalDAV: '', lastModifiedObsidian: '', lastModifiedCalDAV: '' } },
+        caldavToTask: { 'caldav-abc': '20250101-abc' },
+      });
+      mockFindTaskById.mockReturnValue(obsTask);
+
+      const engine = new SyncEngine(new App(), makeSettings());
+      await engine.initialize();
+      const result = await engine.sync(false);
+
+      expect(result.success).toBe(true);
+      expect(result.updated.toObsidian).toBe(1);
+      expect(mockUpdateTaskInVault).toHaveBeenCalledTimes(1);
+
+      // The markdown written to vault should have [x], the due date, AND the completion date
+      const newMarkdown = mockUpdateTaskInVault.mock.calls[0][1] as string;
+      expect(newMarkdown).toContain('- [x]');
+      expect(newMarkdown).toContain('📅 2025-07-01');
+      expect(newMarkdown).toContain('✅ 2025-07-15');
+      expect(newMarkdown).toContain('🆔 20250101-abc');
+    });
   });
 
   describe('mapping updates after sync', () => {

--- a/test/e2e/syncRoundTrip.e2e.test.ts
+++ b/test/e2e/syncRoundTrip.e2e.test.ts
@@ -175,6 +175,7 @@ describe('Sync round-trip E2E', () => {
     expect(changeset.toObsidian).toHaveLength(1);
     expect(changeset.toObsidian[0].type).toBe('update');
     expect(changeset.toObsidian[0].task.status).toBe('DONE');
+    expect(changeset.toObsidian[0].task.completedDate).toBe('2025-07-01');
     expect(changeset.toCalDAV).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Summary
- Add unit test in `syncEngine.test.ts` verifying the full pipeline: CalDAV COMPLETED date → CommonTask → markdown with `✅ YYYY-MM-DD`
- Add assertion to e2e `syncRoundTrip.e2e.test.ts` verifying `completedDate` is present in changeset

## Result
**No bug found** — the completion date is correctly preserved through the entire pipeline. The test confirms:
- `- [x]` status ✓
- `📅 2025-07-01` due date ✓
- `✅ 2025-07-15` completion date ✓
- `🆔 task-id` ✓

## Related
- #40 (recurring task completion — separate issue, still valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)