### PR TITLE
fix: generate task IDs in memory, write only after sync succeeds

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,6 @@
 import { App, Editor, MarkdownView, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
 import { CalDAVSettings, DEFAULT_CALDAV_SETTINGS } from './src/types';
-import { ensureTaskId, extractTaskId, isValidTaskId } from './src/utils/taskIdGenerator';
+import { extractTaskId, isValidTaskId } from './src/utils/taskIdGenerator';
 import { SyncEngine } from './src/sync/syncEngine';
 import { dumpCalDAVRequests } from './src/caldav/requestDumper';
 import { SyncResultModal } from './src/ui/syncResultModal';
@@ -20,56 +20,6 @@ export default class CalDAVSyncPlugin extends Plugin {
 		if (!ready) {
 			new Notice('CalDAV sync: obsidian-tasks plugin not available');
 		}
-
-		// Command: Inject task IDs into selected lines
-		this.addCommand({
-			id: 'inject-task-ids',
-			name: 'Inject task ids into selected tasks',
-			editorCallback: (editor: Editor, _view: MarkdownView) => {
-				const selection = editor.getSelection();
-
-				if (selection) {
-					// Process selected text
-					const lines = selection.split('\n');
-					const processedLines = lines.map(line => {
-						// Only process lines that look like tasks
-						if (line.trim().match(/^-\s*\[.\]\s+/)) {
-							const result = ensureTaskId(line);
-							if (result.modified) {
-								return result.text;
-							}
-						}
-						return line;
-					});
-
-					const newText = processedLines.join('\n');
-					editor.replaceSelection(newText);
-
-					const addedCount = processedLines.filter((line, i) => line !== lines[i]).length;
-					if (addedCount > 0) {
-						new Notice(`Added IDs to ${addedCount} task(s)`);
-					} else {
-						new Notice('All tasks already have ids');
-					}
-				} else {
-					// Process current line
-					const cursor = editor.getCursor();
-					const line = editor.getLine(cursor.line);
-
-					if (line.trim().match(/^-\s*\[.\]\s+/)) {
-						const result = ensureTaskId(line);
-						if (result.modified) {
-							editor.setLine(cursor.line, result.text);
-							new Notice('Added task ID');
-						} else {
-							new Notice('Task already has an ID');
-						}
-					} else {
-						new Notice('Current line is not a task');
-					}
-				}
-			}
-		});
 
 		// Command: Validate task IDs in document
 		this.addCommand({

--- a/src/sync/obsidianAdapter.test.ts
+++ b/src/sync/obsidianAdapter.test.ts
@@ -1,4 +1,4 @@
-import { ObsidianAdapter } from './obsidianAdapter';
+import { ObsidianAdapter, TaskWithNotes } from './obsidianAdapter';
 import { ObsidianTask } from '../tasks/taskManager';
 
 function makeTask(overrides: Partial<ObsidianTask> = {}): ObsidianTask {
@@ -20,6 +20,10 @@ function makeTask(overrides: Partial<ObsidianTask> = {}): ObsidianTask {
     id: '20250105-a4f',
     ...overrides,
   };
+}
+
+function withNotes(task: ObsidianTask, notes: string = ''): TaskWithNotes {
+  return { task, notes };
 }
 
 describe('ObsidianAdapter', () => {
@@ -132,54 +136,85 @@ describe('ObsidianAdapter', () => {
 
   describe('normalize', () => {
     it('should filter by sync tag', () => {
-      const tasks = [
-        makeTask({ description: 'Task 1', tags: ['#sync'] }),
-        makeTask({ description: 'Task 2', tags: ['#work'], id: '20250105-b00', originalMarkdown: '- [ ] Task 2 🆔 20250105-b00 #work' }),
-        makeTask({ description: 'Task 3', tags: ['#sync', '#work'], id: '20250105-c00', originalMarkdown: '- [ ] Task 3 🆔 20250105-c00 #sync #work' }),
+      const inputs: TaskWithNotes[] = [
+        withNotes(makeTask({ description: 'Task 1', tags: ['#sync'] })),
+        withNotes(makeTask({ description: 'Task 2', tags: ['#work'], id: '20250105-b00', originalMarkdown: '- [ ] Task 2 🆔 20250105-b00 #work' })),
+        withNotes(makeTask({ description: 'Task 3', tags: ['#sync', '#work'], id: '20250105-c00', originalMarkdown: '- [ ] Task 3 🆔 20250105-c00 #sync #work' })),
       ];
 
-      const result = adapter.normalize(tasks, 'sync');
-      expect(result).toHaveLength(2);
-      expect(result[0].title).toBe('Task 1');
-      expect(result[1].title).toBe('Task 3');
+      const { tasks } = adapter.normalize(inputs, 'sync');
+      expect(tasks).toHaveLength(2);
+      expect(tasks[0].title).toBe('Task 1');
+      expect(tasks[1].title).toBe('Task 3');
     });
 
     it('should return all tasks when syncTag is empty', () => {
-      const tasks = [
-        makeTask({ description: 'Task 1', tags: ['#work'], id: 'id1', originalMarkdown: '- [ ] Task 1 🆔 id1 #work' }),
-        makeTask({ description: 'Task 2', tags: [], id: 'id2', originalMarkdown: '- [ ] Task 2 🆔 id2' }),
+      const inputs: TaskWithNotes[] = [
+        withNotes(makeTask({ description: 'Task 1', tags: ['#work'], id: 'id1', originalMarkdown: '- [ ] Task 1 🆔 id1 #work' })),
+        withNotes(makeTask({ description: 'Task 2', tags: [], id: 'id2', originalMarkdown: '- [ ] Task 2 🆔 id2' })),
       ];
 
-      const result = adapter.normalize(tasks, '');
-      expect(result).toHaveLength(2);
+      const { tasks } = adapter.normalize(inputs, '');
+      expect(tasks).toHaveLength(2);
     });
 
-    it('should skip tasks without IDs', () => {
-      const tasks = [
-        makeTask({ id: '', originalMarkdown: '- [ ] No ID #sync' }),
+    it('should generate IDs for tasks without them', () => {
+      const inputs: TaskWithNotes[] = [
+        withNotes(makeTask({ id: '', originalMarkdown: '- [ ] No ID #sync' })),
       ];
 
-      const result = adapter.normalize(tasks, 'sync');
-      expect(result).toHaveLength(0);
+      const { tasks, tasksById } = adapter.normalize(inputs, 'sync');
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].uid).toMatch(/^\d{8}-[0-9a-f]{3}$/);
+      // tasksById should map the generated ID to the original task
+      expect(tasksById.get(tasks[0].uid)).toBe(inputs[0].task);
+    });
+
+    it('should preserve existing IDs', () => {
+      const inputs: TaskWithNotes[] = [
+        withNotes(makeTask({ id: '20250105-a4f' })),
+      ];
+
+      const { tasks, tasksById } = adapter.normalize(inputs, 'sync');
+      expect(tasks[0].uid).toBe('20250105-a4f');
+      expect(tasksById.get('20250105-a4f')).toBe(inputs[0].task);
     });
 
     it('should handle case-insensitive tag matching', () => {
-      const tasks = [
-        makeTask({ tags: ['#SYNC'], id: 'id1', originalMarkdown: '- [ ] Task 🆔 id1 #SYNC' }),
-        makeTask({ tags: ['#Sync'], id: 'id2', originalMarkdown: '- [ ] Task 🆔 id2 #Sync' }),
+      const inputs: TaskWithNotes[] = [
+        withNotes(makeTask({ tags: ['#SYNC'], id: 'id1', originalMarkdown: '- [ ] Task 🆔 id1 #SYNC' })),
+        withNotes(makeTask({ tags: ['#Sync'], id: 'id2', originalMarkdown: '- [ ] Task 🆔 id2 #Sync' })),
       ];
 
-      const result = adapter.normalize(tasks, 'sync');
-      expect(result).toHaveLength(2);
+      const { tasks } = adapter.normalize(inputs, 'sync');
+      expect(tasks).toHaveLength(2);
     });
 
     it('should handle syncTag with # prefix', () => {
-      const tasks = [
-        makeTask({ tags: ['#sync'] }),
+      const inputs: TaskWithNotes[] = [
+        withNotes(makeTask({ tags: ['#sync'] })),
       ];
 
-      const result = adapter.normalize(tasks, '#sync');
-      expect(result).toHaveLength(1);
+      const { tasks } = adapter.normalize(inputs, '#sync');
+      expect(tasks).toHaveLength(1);
+    });
+
+    it('should include notes from task inputs', () => {
+      const inputs: TaskWithNotes[] = [
+        { task: makeTask({ id: 'task-1', tags: ['#sync'] }), notes: 'Some notes' },
+      ];
+      const { tasks } = adapter.normalize(inputs, 'sync');
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].notes).toBe('Some notes');
+    });
+
+    it('should default to empty notes', () => {
+      const inputs: TaskWithNotes[] = [
+        withNotes(makeTask({ id: 'task-1', tags: ['#sync'] })),
+      ];
+      const { tasks } = adapter.normalize(inputs, 'sync');
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].notes).toBe('');
     });
   });
 
@@ -474,31 +509,6 @@ describe('ObsidianAdapter', () => {
       const content = '- [ ] Task\n    Not a bullet line\n    - Actual note';
       const notes = adapter.extractNotesFromFile(content, 0);
       expect(notes).toBe('');
-    });
-  });
-
-  describe('normalize with notesMap', () => {
-    it('should include notes from notesMap in CommonTask', () => {
-      const task = makeTask({ id: 'task-1', tags: ['#sync'] });
-      const notesMap = new Map([['task-1', 'Some notes']]);
-      const result = adapter.normalize([task], 'sync', notesMap);
-      expect(result).toHaveLength(1);
-      expect(result[0].notes).toBe('Some notes');
-    });
-
-    it('should default to empty notes when not in notesMap', () => {
-      const task = makeTask({ id: 'task-1', tags: ['#sync'] });
-      const notesMap = new Map<string, string>();
-      const result = adapter.normalize([task], 'sync', notesMap);
-      expect(result).toHaveLength(1);
-      expect(result[0].notes).toBe('');
-    });
-
-    it('should default to empty notes when notesMap is not provided', () => {
-      const task = makeTask({ id: 'task-1', tags: ['#sync'] });
-      const result = adapter.normalize([task], 'sync');
-      expect(result).toHaveLength(1);
-      expect(result[0].notes).toBe('');
     });
   });
 

--- a/src/sync/obsidianAdapter.ts
+++ b/src/sync/obsidianAdapter.ts
@@ -1,26 +1,39 @@
 import { RRule } from 'rrule';
 import { CommonTask, TaskStatus, TaskPriority } from './types';
 import { ObsidianTask } from '../tasks/taskManager';
+import { generateTaskId } from '../utils/taskIdGenerator';
+
+export interface TaskWithNotes {
+  task: ObsidianTask;
+  notes: string;
+}
+
+export interface NormalizeResult {
+  tasks: CommonTask[];
+  tasksById: Map<string, ObsidianTask>;
+}
 
 export class ObsidianAdapter {
   /**
    * Normalize obsidian-tasks Task[] into CommonTask[].
-   * Only includes tasks that have an ID and pass the sync tag filter.
-   * @param notesMap Optional map of taskId -> notes text (extracted from vault files)
+   * Filters by sync tag, generates in-memory IDs for tasks without one.
+   * Returns both the normalized tasks and a map from uid → original ObsidianTask.
    */
-  normalize(tasks: ObsidianTask[], syncTag?: string, notesMap?: Map<string, string>): CommonTask[] {
-    const filtered = this.filterByTag(tasks, syncTag);
-    const result: CommonTask[] = [];
+  normalize(taskInputs: TaskWithNotes[], syncTag?: string): NormalizeResult {
+    const filtered = this.filterByTag(taskInputs, syncTag);
+    const tasks: CommonTask[] = [];
+    const tasksById = new Map<string, ObsidianTask>();
 
-    for (const task of filtered) {
-      const taskId = this.extractId(task);
-      if (!taskId) continue;
-
-      const notes = notesMap?.get(taskId) ?? '';
-      result.push(this.toCommonTask(task, taskId, notes));
+    for (const { task, notes } of filtered) {
+      let taskId = this.extractId(task);
+      if (!taskId) {
+        taskId = generateTaskId();
+      }
+      tasksById.set(taskId, task);
+      tasks.push(this.toCommonTask(task, taskId, notes));
     }
 
-    return result;
+    return { tasks, tasksById };
   }
 
   /**
@@ -217,11 +230,11 @@ export class ObsidianAdapter {
   /**
    * Filter tasks by sync tag.
    */
-  private filterByTag(tasks: ObsidianTask[], syncTag?: string): ObsidianTask[] {
-    if (!syncTag || syncTag.trim() === '') return tasks;
+  private filterByTag(inputs: TaskWithNotes[], syncTag?: string): TaskWithNotes[] {
+    if (!syncTag || syncTag.trim() === '') return inputs;
 
     const tagLower = syncTag.toLowerCase().replace(/^#/, '');
-    return tasks.filter(task => {
+    return inputs.filter(({ task }) => {
       if (!task.tags || task.tags.length === 0) return false;
       return task.tags.some((tag: string) =>
         tag.toLowerCase().replace(/^#/, '') === tagLower

--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -70,7 +70,6 @@ function makeCalObj(uid: string, summary: string, extra: string[] = []): Calenda
 
 const mockTaskManagerInitialize = jest.fn().mockReturnValue(true);
 const mockGetAllTasks = jest.fn().mockReturnValue([]);
-const mockEnsureTaskHasId = jest.fn().mockResolvedValue('mock-id');
 const mockFindTaskById = jest.fn().mockReturnValue(null);
 const mockCreateTask = jest.fn().mockResolvedValue(undefined);
 const mockUpdateTaskInVault = jest.fn().mockResolvedValue(undefined);
@@ -80,7 +79,6 @@ jest.mock('../tasks/taskManager', () => ({
   TaskManager: jest.fn().mockImplementation(() => ({
     initialize: mockTaskManagerInitialize,
     getAllTasks: mockGetAllTasks,
-    ensureTaskHasId: mockEnsureTaskHasId,
     findTaskById: mockFindTaskById,
     createTask: mockCreateTask,
     updateTaskInVault: mockUpdateTaskInVault,
@@ -140,7 +138,6 @@ describe('SyncEngine', () => {
     // so we must explicitly reset any fn that a test reconfigures.
     mockTaskManagerInitialize.mockReturnValue(true);
     mockGetAllTasks.mockReturnValue([]);
-    mockEnsureTaskHasId.mockResolvedValue('mock-id');
     mockFindTaskById.mockReturnValue(null);
     mockCreateTask.mockResolvedValue(undefined);
     mockUpdateTaskInVault.mockResolvedValue(undefined);
@@ -507,8 +504,66 @@ describe('SyncEngine', () => {
     });
   });
 
-  describe('sync tag filtering for ID injection', () => {
-    it('should only inject IDs into tasks matching the sync tag', async () => {
+  describe('ID writeback after sync', () => {
+    it('should write IDs to vault after successful sync for tasks without IDs', async () => {
+      const task = makeObsidianTask({
+        description: 'Task without ID',
+        tags: ['#sync'],
+        id: '',
+        originalMarkdown: '- [ ] Task without ID #sync',
+      });
+
+      mockGetAllTasks.mockReturnValue([task]);
+
+      const engine = new SyncEngine(new App(), makeSettings());
+      await engine.initialize();
+      const result = await engine.sync(false);
+
+      expect(result.success).toBe(true);
+      // Should write ID back to vault via updateTaskInVault
+      expect(mockUpdateTaskInVault).toHaveBeenCalledTimes(1);
+      const newMarkdown = (mockUpdateTaskInVault.mock.calls[0] as [ObsidianTask, string])[1];
+      expect(newMarkdown).toContain('🆔');
+    });
+
+    it('should not write IDs during dry run', async () => {
+      const task = makeObsidianTask({
+        description: 'Task without ID',
+        tags: ['#sync'],
+        id: '',
+        originalMarkdown: '- [ ] Task without ID #sync',
+      });
+
+      mockGetAllTasks.mockReturnValue([task]);
+
+      const engine = new SyncEngine(new App(), makeSettings());
+      await engine.initialize();
+      const result = await engine.sync(true);
+
+      expect(result.success).toBe(true);
+      expect(mockUpdateTaskInVault).not.toHaveBeenCalled();
+    });
+
+    it('should not write IDs for tasks that already have them', async () => {
+      const task = makeObsidianTask({
+        description: 'Task with ID',
+        tags: ['#sync'],
+        id: '20250101-abc',
+        originalMarkdown: '- [ ] Task with ID 🆔 20250101-abc #sync',
+      });
+
+      mockGetAllTasks.mockReturnValue([task]);
+
+      const engine = new SyncEngine(new App(), makeSettings());
+      await engine.initialize();
+      await engine.sync(false);
+
+      // updateTaskInVault should NOT be called for ID writeback
+      // (it might be called for other sync changes, but not for this task's ID)
+      expect(mockUpdateTaskInVault).not.toHaveBeenCalled();
+    });
+
+    it('should only write IDs for tasks matching the sync tag', async () => {
       const syncedTask = makeObsidianTask({
         description: 'Synced task',
         tags: ['#sync'],
@@ -526,85 +581,14 @@ describe('SyncEngine', () => {
 
       const engine = new SyncEngine(new App(), makeSettings({ syncTag: 'sync' }));
       await engine.initialize();
-      await engine.sync(true);
+      await engine.sync(false);
 
-      expect(mockEnsureTaskHasId).toHaveBeenCalledTimes(1);
-      expect(mockEnsureTaskHasId).toHaveBeenCalledWith(syncedTask);
-    });
-
-    it('should not inject IDs into any task when none match the sync tag', async () => {
-      const task1 = makeObsidianTask({
-        description: 'Work task',
-        tags: ['#work'],
-        originalMarkdown: '- [ ] Work task #work',
-      });
-      const task2 = makeObsidianTask({
-        description: 'Personal task',
-        tags: ['#personal'],
-        originalMarkdown: '- [ ] Personal task #personal',
-      });
-
-      mockGetAllTasks.mockReturnValue([task1, task2]);
-
-      const engine = new SyncEngine(new App(), makeSettings({ syncTag: 'sync' }));
-      await engine.initialize();
-      await engine.sync(true);
-
-      expect(mockEnsureTaskHasId).not.toHaveBeenCalled();
-    });
-
-    it('should inject IDs into all tasks when sync tag is empty', async () => {
-      const task1 = makeObsidianTask({
-        description: 'Task A',
-        tags: ['#work'],
-        originalMarkdown: '- [ ] Task A #work',
-      });
-      const task2 = makeObsidianTask({
-        description: 'Task B',
-        tags: [],
-        originalMarkdown: '- [ ] Task B',
-      });
-
-      mockGetAllTasks.mockReturnValue([task1, task2]);
-
-      const engine = new SyncEngine(new App(), makeSettings({ syncTag: '' }));
-      await engine.initialize();
-      await engine.sync(true);
-
-      expect(mockEnsureTaskHasId).toHaveBeenCalledTimes(2);
-    });
-
-    it('should match sync tag case-insensitively', async () => {
-      const task = makeObsidianTask({
-        description: 'Mixed case',
-        tags: ['#Sync'],
-        originalMarkdown: '- [ ] Mixed case #Sync',
-      });
-
-      mockGetAllTasks.mockReturnValue([task]);
-
-      const engine = new SyncEngine(new App(), makeSettings({ syncTag: 'sync' }));
-      await engine.initialize();
-      await engine.sync(true);
-
-      expect(mockEnsureTaskHasId).toHaveBeenCalledTimes(1);
-      expect(mockEnsureTaskHasId).toHaveBeenCalledWith(task);
-    });
-
-    it('should handle sync tag with # prefix in settings', async () => {
-      const task = makeObsidianTask({
-        description: 'Tagged task',
-        tags: ['#sync'],
-        originalMarkdown: '- [ ] Tagged task #sync',
-      });
-
-      mockGetAllTasks.mockReturnValue([task]);
-
-      const engine = new SyncEngine(new App(), makeSettings({ syncTag: '#sync' }));
-      await engine.initialize();
-      await engine.sync(true);
-
-      expect(mockEnsureTaskHasId).toHaveBeenCalledTimes(1);
+      // Only the synced task should get an ID written back
+      const writebackCalls = mockUpdateTaskInVault.mock.calls.filter(
+        (call: [ObsidianTask, string]) => call[1].includes('🆔')
+      );
+      expect(writebackCalls).toHaveLength(1);
+      expect((writebackCalls[0] as [ObsidianTask, string])[0]).toBe(syncedTask);
     });
   });
 
@@ -949,7 +933,6 @@ describe('SyncEngine', () => {
       mockDeleteVTODOByUID.mockResolvedValue(undefined);
       mockCreateTask.mockResolvedValue(undefined);
       mockUpdateTaskInVault.mockResolvedValue(undefined);
-      mockEnsureTaskHasId.mockResolvedValue('20250101-aaa');
       mockFetchVTODOByUID.mockResolvedValue(null);
 
       // Obsidian still has the same task

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -4,7 +4,7 @@ import { CalDAVClientDirect } from '../caldav/calDAVClientDirect';
 import { SyncStorage } from '../storage/syncStorage';
 import { CalDAVSettings } from '../types';
 import { CalDAVAdapter } from './caldavAdapter';
-import { ObsidianAdapter } from './obsidianAdapter';
+import { ObsidianAdapter, TaskWithNotes } from './obsidianAdapter';
 import { diff } from './diff';
 import { CommonTask, Conflict, ConflictStrategy, SyncChange } from './types';
 import { generateTaskId } from '../utils/taskIdGenerator';
@@ -70,18 +70,12 @@ export class SyncEngine {
       const allCaldavTasks = this.caldavAdapter.normalize(vtodos, uidMapping);
       const caldavTasks = this.filterCalDAVBySyncTag(allCaldavTasks, uidMapping);
 
-      // 3. Get Obsidian tasks → filter by sync tag → inject IDs only on matching tasks
+      // 3. Get Obsidian tasks → pair with notes → normalize (IDs generated in memory)
       const allObsidianTasks = this.taskManager.getAllTasks();
-      const syncTagFiltered = this.filterBySyncTag(allObsidianTasks);
-      for (const task of syncTagFiltered) {
-        await this.taskManager.ensureTaskHasId(task);
-      }
-      const refreshedTasks = this.taskManager.getAllTasks(); // Re-fetch after ID injection
-      const notesMap = await this.buildNotesMap(refreshedTasks);
-      const obsidianTasks = this.obsidianAdapter.normalize(
-        refreshedTasks,
+      const taskInputs = await this.buildTaskInputs(allObsidianTasks);
+      const { tasks: obsidianTasks, tasksById } = this.obsidianAdapter.normalize(
+        taskInputs,
         this.settings.syncTag,
-        notesMap,
       );
       // 4. Load baseline — if empty, seed from already-mapped tasks so the
       //    first sync with this engine doesn't duplicate everything.
@@ -131,19 +125,22 @@ export class SyncEngine {
       }
 
       // 6. Apply changes to Obsidian
-      await this.applyObsidianChanges(changeset.toObsidian);
+      await this.applyObsidianChanges(changeset.toObsidian, tasksById);
 
       // 7. Apply changes to CalDAV
       await this.caldavAdapter.applyChanges(changeset.toCalDAV, this.caldavClient, uidMapping);
 
-      // 8. Update mappings for new tasks
-      this.updateMappingsAfterSync(changeset);
+      // 8. Write back IDs for tasks that got in-memory IDs
+      await this.writeBackIds(obsidianTasks, tasksById);
 
-      // 9. Save new baseline (union of current state after applying changes)
+      // 9. Update mappings for new tasks
+      this.updateMappingsAfterSync(changeset, tasksById);
+
+      // 10. Save new baseline (union of current state after applying changes)
       const newBaseline = this.computeNewBaseline(obsidianTasks, caldavTasks, changeset);
       this.storage.setBaseline(newBaseline);
 
-      // 10. Save state
+      // 11. Save state
       this.storage.updateLastSyncTime();
       await this.storage.save();
 
@@ -182,23 +179,6 @@ export class SyncEngine {
     const conflicts = state.conflicts.length;
 
     return `Last sync: ${lastSync}\nMapped tasks: ${mappedTasks}\nBaseline tasks: ${baselineTasks}\nConflicts: ${conflicts}`;
-  }
-
-  /**
-   * Filter Obsidian tasks by the configured sync tag.
-   * Only these tasks should get IDs injected and be synced.
-   */
-  private filterBySyncTag(tasks: ObsidianTask[]): ObsidianTask[] {
-    const syncTag = this.settings.syncTag;
-    if (!syncTag || syncTag.trim() === '') return tasks;
-
-    const tagLower = syncTag.toLowerCase().replace(/^#/, '');
-    return tasks.filter(task => {
-      if (!task.tags || task.tags.length === 0) return false;
-      return task.tags.some((tag: string) =>
-        tag.toLowerCase().replace(/^#/, '') === tagLower
-      );
-    });
   }
 
   /**
@@ -265,8 +245,13 @@ export class SyncEngine {
 
   /**
    * Apply changes to Obsidian vault (creates, updates, deletes).
+   * @param tasksById Map from uid → original ObsidianTask, used to find tasks
+   *   that may not yet be in obsidian-tasks cache (e.g. tasks with in-memory IDs).
    */
-  private async applyObsidianChanges(changes: SyncChange[]): Promise<void> {
+  private async applyObsidianChanges(
+    changes: SyncChange[],
+    tasksById: Map<string, ObsidianTask>,
+  ): Promise<void> {
     for (const change of changes) {
       try {
         switch (change.type) {
@@ -290,7 +275,8 @@ export class SyncEngine {
           }
 
           case 'update': {
-            const existingTask = this.taskManager.findTaskById(change.task.uid);
+            const existingTask = tasksById.get(change.task.uid)
+              ?? this.taskManager.findTaskById(change.task.uid);
             if (!existingTask) continue;
 
             const markdown = this.obsidianAdapter.toMarkdown(
@@ -319,14 +305,18 @@ export class SyncEngine {
   /**
    * Update mappings after sync to track newly created tasks.
    */
-  private updateMappingsAfterSync(changeset: { toObsidian: SyncChange[]; toCalDAV: SyncChange[] }): void {
+  private updateMappingsAfterSync(
+    changeset: { toObsidian: SyncChange[]; toCalDAV: SyncChange[] },
+    tasksById: Map<string, ObsidianTask>,
+  ): void {
     // For tasks created on CalDAV side, the mapping was already added in applyObsidianChanges.
 
     // For tasks created on CalDAV from Obsidian, add mapping.
     for (const change of changeset.toCalDAV) {
       if (change.type === 'create') {
         const caldavUID = `obsidian-${change.task.uid}`;
-        const existingTask = this.taskManager.findTaskById(change.task.uid);
+        const existingTask = tasksById.get(change.task.uid)
+          ?? this.taskManager.findTaskById(change.task.uid);
         const sourceFile = existingTask
           ? existingTask.taskLocation._tasksFile._path
           : this.settings.newTasksDestination;
@@ -342,11 +332,11 @@ export class SyncEngine {
   }
 
   /**
-   * Build a map of taskId → notes by reading vault files and extracting
-   * indented bullets below each task line.
+   * Pair each task with its notes extracted from vault files.
+   * Groups tasks by file to avoid re-reading the same file multiple times.
    */
-  private async buildNotesMap(tasks: ObsidianTask[]): Promise<Map<string, string>> {
-    const notesMap = new Map<string, string>();
+  private async buildTaskInputs(tasks: ObsidianTask[]): Promise<TaskWithNotes[]> {
+    const result: TaskWithNotes[] = [];
 
     // Group tasks by file to avoid re-reading the same file
     const tasksByFile = new Map<string, ObsidianTask[]>();
@@ -361,30 +351,63 @@ export class SyncEngine {
     for (const [filePath, fileTasks] of tasksByFile) {
       try {
         const file = this.app.vault.getAbstractFileByPath(filePath);
-        if (!file || !(file instanceof TFile)) continue;
+        if (!file || !(file instanceof TFile)) {
+          for (const task of fileTasks) {
+            result.push({ task, notes: '' });
+          }
+          continue;
+        }
         const content = await this.app.vault.read(file);
         const lines = content.split('\n');
 
         for (const task of fileTasks) {
-          const taskId = this.taskManager.getTaskId(task);
-          if (!taskId) continue;
-
           const lineIndex = lines.findIndex(
             line => line.trim() === task.originalMarkdown.trim()
           );
-          if (lineIndex === -1) continue;
+          if (lineIndex === -1) {
+            result.push({ task, notes: '' });
+            continue;
+          }
 
           const notes = this.obsidianAdapter.extractNotesFromFile(content, lineIndex);
-          if (notes) {
-            notesMap.set(taskId, notes);
-          }
+          result.push({ task, notes });
         }
       } catch (error) {
         console.error(`[SyncEngine] Failed to read file for notes: ${filePath}`, error);
+        for (const task of fileTasks) {
+          result.push({ task, notes: '' });
+        }
       }
     }
 
-    return notesMap;
+    return result;
+  }
+
+  /**
+   * Write IDs back to vault for tasks that had in-memory IDs generated during normalize.
+   * Only called after sync succeeds, so IDs are only persisted when sync completes.
+   */
+  private async writeBackIds(
+    obsidianTasks: CommonTask[],
+    tasksById: Map<string, ObsidianTask>,
+  ): Promise<void> {
+    for (const task of obsidianTasks) {
+      const original = tasksById.get(task.uid);
+      if (!original) continue;
+      // Only write back if the original task had no ID
+      if (this.obsidianAdapter.extractId(original)) continue;
+
+      try {
+        const markdown = this.obsidianAdapter.toMarkdown(
+          task,
+          task.uid,
+          this.settings.syncTag,
+        );
+        await this.taskManager.updateTaskInVault(original, markdown);
+      } catch (error) {
+        console.error(`[SyncEngine] Failed to write back ID for task ${task.uid}:`, error);
+      }
+    }
   }
 
   /**

--- a/src/tasks/taskManager.test.ts
+++ b/src/tasks/taskManager.test.ts
@@ -412,62 +412,6 @@ describe('TaskManager', () => {
         });
     });
 
-    describe('ensureTaskHasId', () => {
-        let mockFile: MockTFile;
-
-        beforeEach(() => {
-            mockFile = new MockTFile('test.md');
-            jest.clearAllMocks();
-        });
-
-        it('should return existing ID without updating vault', async () => {
-            const task = createMockTask({
-                id: 'existing-id-123',
-                originalMarkdown: '- [ ] Task with ID [id::existing-id-123]',
-                taskLocation: {
-                    _tasksFile: { _path: 'test.md' },
-                    _lineNumber: 1
-                }
-            });
-
-            const result = await taskManager.ensureTaskHasId(task);
-
-            expect(result).toBe('existing-id-123');
-            expect(mockApp.vault.modify).not.toHaveBeenCalled();
-        });
-
-        it('should generate and inject new ID when task has none', async () => {
-            const fileContent = '- [ ] Task without ID';
-
-            const task = createMockTask({
-                id: '',
-                description: 'Task without ID',
-                originalMarkdown: '- [ ] Task without ID',
-                taskLocation: {
-                    _tasksFile: { _path: 'test.md' },
-                    _lineNumber: 1
-                }
-            });
-
-            mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
-            mockApp.vault.read.mockResolvedValue(fileContent);
-            mockApp.vault.modify.mockResolvedValue(undefined);
-
-            const result = await taskManager.ensureTaskHasId(task);
-
-            // Should return a non-empty ID
-            expect(result).toBeTruthy();
-            expect(result.length).toBeGreaterThan(0);
-
-            // Should have called updateTaskInVault (which calls vault.modify)
-            expect(mockApp.vault.modify).toHaveBeenCalledTimes(1);
-
-            // The modified content should contain the new ID
-            const updatedContent = (mockApp.vault.modify.mock.calls[0] as [unknown, string])[1];
-            expect(updatedContent).toContain(`🆔 ${result}`);
-        });
-    });
-
     describe('updateTaskInVault', () => {
         let mockFile: MockTFile;
 

--- a/src/tasks/taskManager.ts
+++ b/src/tasks/taskManager.ts
@@ -1,5 +1,5 @@
 import { App, TFile } from 'obsidian';
-import { ensureTaskId, extractTaskId } from '../utils/taskIdGenerator';
+import { extractTaskId } from '../utils/taskIdGenerator';
 
 /**
  * Represents a task from obsidian-tasks plugin
@@ -183,26 +183,6 @@ export class TaskManager {
         }
 
         return null;
-    }
-
-    /**
-     * Ensure a task has an ID, inject if missing
-     * @returns The task ID (existing or newly generated)
-     */
-    async ensureTaskHasId(task: ObsidianTask): Promise<string> {
-        const existingId = this.getTaskId(task);
-        if (existingId) {
-            return existingId;
-        }
-
-        // Insert ID before obsidian-tasks metadata (dates, priority, tags)
-        const result = ensureTaskId(task.originalMarkdown);
-
-        if (result.modified) {
-            await this.updateTaskInVault(task, result.text);
-        }
-
-        return result.id;
     }
 
     /**

--- a/src/utils/taskIdGenerator.test.ts
+++ b/src/utils/taskIdGenerator.test.ts
@@ -1,7 +1,6 @@
 import {
   generateTaskId,
   extractTaskId,
-  ensureTaskId,
   isValidTaskId
 } from './taskIdGenerator';
 
@@ -74,77 +73,6 @@ describe('taskIdGenerator', () => {
       const taskText = '- [ ] Task [id::20250105-f9e]';
       const id = extractTaskId(taskText);
       expect(id).toBe('20250105-f9e');
-    });
-  });
-
-  describe('ensureTaskId', () => {
-    it('should return existing ID when present', () => {
-      const taskText = '- [ ] Task [id::20250105-abc]';
-      const result = ensureTaskId(taskText);
-
-      expect(result.id).toBe('20250105-abc');
-      expect(result.text).toBe(taskText);
-      expect(result.modified).toBe(false);
-    });
-
-    it('should inject ID into task text', () => {
-      const taskText = '- [ ] Task without ID';
-      const result = ensureTaskId(taskText);
-
-      expect(result.id).toMatch(/^\d{8}-[0-9a-f]{3}$/);
-      expect(result.text).toContain(`🆔 ${result.id}`);
-      expect(result.modified).toBe(true);
-    });
-
-    it('should append ID at end when no metadata present', () => {
-      const taskText = '- [ ] Some task';
-      const result = ensureTaskId(taskText);
-
-      expect(result.text).toMatch(/^- \[ \] Some task 🆔 \d{8}-[0-9a-f]{3}$/);
-    });
-
-    it('should insert ID before date emojis', () => {
-      const taskText = '- [ ] Buy groceries 📅 2025-01-15';
-      const result = ensureTaskId(taskText);
-
-      expect(result.text).toMatch(/^- \[ \] Buy groceries 🆔 \d{8}-[0-9a-f]{3} 📅 2025-01-15$/);
-    });
-
-    it('should insert ID before multiple date emojis', () => {
-      const taskText = '- [ ] Task 🛫 2025-01-08 ⏳ 2025-01-10 📅 2025-01-15';
-      const result = ensureTaskId(taskText);
-
-      expect(result.text).toMatch(/^- \[ \] Task 🆔 \S+ 🛫 2025-01-08 ⏳ 2025-01-10 📅 2025-01-15$/);
-    });
-
-    it('should insert ID before tags', () => {
-      const taskText = '- [ ] Task #sync #work';
-      const result = ensureTaskId(taskText);
-
-      expect(result.text).toMatch(/^- \[ \] Task 🆔 \S+ #sync #work$/);
-    });
-
-    it('should insert ID before priority emoji', () => {
-      const taskText = '- [ ] Task ⏫ 📅 2025-01-15';
-      const result = ensureTaskId(taskText);
-
-      expect(result.text).toMatch(/^- \[ \] Task 🆔 \S+ ⏫ 📅 2025-01-15$/);
-    });
-
-    it('should not modify text that already has dataview ID', () => {
-      const taskText = '- [ ] Task [id::20250105-abc] with extra text';
-      const result = ensureTaskId(taskText);
-
-      expect(result.text).toBe(taskText);
-      expect(result.modified).toBe(false);
-    });
-
-    it('should not modify text that already has emoji ID', () => {
-      const taskText = '- [ ] Task 🆔 20250105-abc with extra text';
-      const result = ensureTaskId(taskText);
-
-      expect(result.text).toBe(taskText);
-      expect(result.modified).toBe(false);
     });
   });
 

--- a/src/utils/taskIdGenerator.ts
+++ b/src/utils/taskIdGenerator.ts
@@ -46,36 +46,6 @@ export function extractTaskId(taskText: string): string | null {
 }
 
 /**
- * Inject task ID into task text if not already present.
- * Uses obsidian-tasks emoji format: 🆔 xxx
- * @param taskText The original task text
- * @returns Task text with ID injected (or original if ID already present)
- */
-export function ensureTaskId(taskText: string): { text: string; id: string; modified: boolean } {
-  const existingId = extractTaskId(taskText);
-
-  if (existingId) {
-    return { text: taskText, id: existingId, modified: false };
-  }
-
-  const newId = generateTaskId();
-  const idField = `🆔 ${newId}`;
-
-  // Insert before obsidian-tasks metadata (emoji markers, tags)
-  const metadataPattern = /\s(?:[📅🛫⏳✅🔁⏫🔼🔽⏬➕]|#[a-zA-Z])/u;
-  const match = taskText.match(metadataPattern);
-
-  let textWithId: string;
-  if (match && match.index !== undefined) {
-    textWithId = taskText.slice(0, match.index) + ` ${idField}` + taskText.slice(match.index);
-  } else {
-    textWithId = `${taskText} ${idField}`;
-  }
-
-  return { text: textWithId, id: newId, modified: true };
-}
-
-/**
  * Validate task ID format
  * @param id The task ID to validate
  * @returns true if valid, false otherwise


### PR DESCRIPTION
## Summary

- **Move ID generation into the sync flow** — IDs are generated in memory during `ObsidianAdapter.normalize()` and written to vault only after sync completes successfully via `toMarkdown()`, which places `🆔` correctly
- **Remove `ensureTaskId()` and `ensureTaskHasId()`** — the functions that bypassed the adapter and placed IDs in the wrong position
- **Remove duplicate `filterBySyncTag()`** from SyncEngine — the adapter owns all Obsidian-side filtering
- **Remove `inject-task-ids` editor command** — IDs are now managed by sync only

Net: **-199 lines** across 9 files.

Closes #38, related to #48

## Architecture

```
SyncEngine.sync():
  1. getAllTasks() → buildTaskInputs() (pairs tasks with notes)
  2. obsidianAdapter.normalize() → generates IDs in memory, returns { tasks, tasksById }
  3. diff()
  4. applyObsidianChanges() / applyCalDAVChanges()
  5. writeBackIds() ← NEW: writes IDs to vault only after sync succeeds
  6. save state
```

## Test plan

- [x] `npm test` — 314 tests pass (unit + E2E)
- [x] `npm run build` — no type errors
- [x] `npm run lint` — no lint errors
- [x] Manual: sync a task without an ID → verify ID appears only after sync completes
- [x] Manual: dry run with ID-less tasks → verify no IDs written to vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)