### PR TITLE
fix: preserve colons in SUMMARY when parsing VTODO

### DIFF
--- a/src/caldav/vtodoMapper.test.ts
+++ b/src/caldav/vtodoMapper.test.ts
@@ -643,6 +643,40 @@ END:VTODO`;
       expect(task.body).toBe('Meeting at 10:30 with team: discuss roadmap');
     });
 
+    it('should handle SUMMARY with time range containing colons', () => {
+      const vtodoData = `BEGIN:VTODO
+UID:colon-summary-time
+SUMMARY:09:00 - 09:15 a task
+STATUS:NEEDS-ACTION
+END:VTODO`;
+
+      const vtodo: CalendarObject = {
+        data: vtodoData,
+        etag: 'test-etag',
+        url: 'http://example.com/test.ics'
+      };
+
+      const task = mapper.vtodoToTask(vtodo);
+      expect(task.title).toBe('09:00 - 09:15 a task');
+    });
+
+    it('should handle SUMMARY with URL containing colons', () => {
+      const vtodoData = `BEGIN:VTODO
+UID:colon-summary-url
+SUMMARY:follow up on https://aurl.com
+STATUS:NEEDS-ACTION
+END:VTODO`;
+
+      const vtodo: CalendarObject = {
+        data: vtodoData,
+        etag: 'test-etag',
+        url: 'http://example.com/test.ics'
+      };
+
+      const task = mapper.vtodoToTask(vtodo);
+      expect(task.title).toBe('follow up on https://aurl.com');
+    });
+
     it('should handle folded DESCRIPTION lines', () => {
       const vtodoData = `BEGIN:VTODO\r\nUID:folded-desc\r\nSUMMARY:Task\r\nDESCRIPTION:A very long description that has been \r\n folded by the server into multiple lines\r\nSTATUS:NEEDS-ACTION\r\nEND:VTODO`;
 

--- a/src/caldav/vtodoMapper.ts
+++ b/src/caldav/vtodoMapper.ts
@@ -89,7 +89,7 @@ export class VTODOMapper {
     const data = vtodoMatch ? vtodoMatch[0] : unfolded;
 
     return {
-      title: this.extractProperty(data, 'SUMMARY') || 'Untitled Task',
+      title: this.extractRawProperty(data, 'SUMMARY') || 'Untitled Task',
       status: this.mapStatusFromVTODO(this.extractProperty(data, 'STATUS') || 'NEEDS-ACTION') as CommonTask['status'],
       dueDate: this.extractDateProperty(data, 'DUE'),
       scheduledDate: null,


### PR DESCRIPTION
Closes #53

## Summary
- `extractProperty()` uses `lastIndexOf(':')` to strip iCal parameters, which truncates SUMMARY values containing colons (e.g. `09:00 - 09:15 a task` → `15 a task`)
- Switch SUMMARY extraction to `extractRawProperty()`, which preserves colons in the value (already used for DESCRIPTION)
- Add two regression tests: time ranges and URLs in task titles

## Test plan
- [x] New unit tests for SUMMARY with time colons and URL colons
- [x] All 333 existing tests pass
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)