### PR TITLE
fix: resolve lint issues flagged by obsidian review bot

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -29,6 +29,7 @@ export default tseslint.config(
 			"obsidianmd/ui/sentence-case": ["error", {
 				mode: "strict",
 			}],
+			"@typescript-eslint/require-await": "error",
 		},
 	},
 	// Test files: add jest globals and relax some rules

--- a/src/migrations/migrationRunner.test.ts
+++ b/src/migrations/migrationRunner.test.ts
@@ -35,8 +35,8 @@ describe('runMigrations', () => {
   it('runs all migrations in order', async () => {
     const order: string[] = [];
     const fakeMigrations: Migration[] = [
-      { name: 'first', async run() { order.push('first'); } },
-      { name: 'second', async run() { order.push('second'); } },
+      { name: 'first', async run() { await Promise.resolve(); order.push('first'); } },
+      { name: 'second', async run() { await Promise.resolve(); order.push('second'); } },
     ];
 
     const adapter = createMockAdapter();

--- a/src/sync/obsidianAdapter.test.ts
+++ b/src/sync/obsidianAdapter.test.ts
@@ -121,10 +121,11 @@ describe('ObsidianAdapter', () => {
       const toggleFn = jest.fn().mockReturnValue(
         '- [x] Weekly review 🔁 every week 📅 2026-02-17 ✅ 2026-02-17 🆔 task-001'
       );
+      const updateTaskInVault = jest.fn().mockResolvedValue(undefined);
       const wrapper = {
         ...dummyWrapper,
         getToggleCommand: jest.fn().mockReturnValue(toggleFn),
-        updateTaskInVault: jest.fn().mockResolvedValue(undefined),
+        updateTaskInVault,
         findTaskById: jest.fn().mockReturnValue(null),
       } as unknown as ObsidianTasksWrapper;
 
@@ -157,8 +158,7 @@ describe('ObsidianAdapter', () => {
         existingTask.originalMarkdown,
         existingTask.taskLocation._tasksFile._path,
       );
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(wrapper.updateTaskInVault).toHaveBeenCalled();
+      expect(updateTaskInVault).toHaveBeenCalled();
       expect(result.completionRemappings).toHaveLength(0); // single line = no remapping
     });
 


### PR DESCRIPTION
## Summary
- Enable `@typescript-eslint/require-await` rule to catch async functions without `await`
- Fix mock migrations to properly `await` like real migrations do
- Remove `eslint-disable` for `unbound-method` by extracting mock to a local variable

Addresses review comments from https://github.com/obsidianmd/obsidian-releases/pull/10183#issuecomment-4122643142

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (365 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)