### PR TITLE
fix: support Baïkal/SabreDAV calendar-home-set discovery + E2E suite (#71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,35 @@ jobs:
 
       - name: E2E tests (Nextcloud)
         run: npm run test:e2e:nextcloud
+
+  test-e2e-baikal:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Cache Baïkal image
+        id: cache-baikal
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-cache/baikal.tar
+          key: docker-baikal-${{ hashFiles('docker-compose.yml') }}
+
+      - name: Load or pull Baïkal image
+        run: |
+          mkdir -p /tmp/docker-cache
+          if [ "${{ steps.cache-baikal.outputs.cache-hit }}" = "true" ]; then
+            docker load -i /tmp/docker-cache/baikal.tar
+          else
+            docker pull ckulka/baikal:nginx
+            docker save ckulka/baikal:nginx -o /tmp/docker-cache/baikal.tar
+          fi
+
+      - name: E2E tests (Baïkal)
+        run: npm run test:e2e:baikal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ These notes round-trip to/from CalDAV clients like Thunderbird or Tasks.org.
 | Radicale | Automated E2E suite |
 | Nextcloud | Automated E2E suite |
 | Vikunja | Automated E2E suite |
-| Baïkal (SabreDAV) | Manually verified (issue #71) |
+| Baïkal (SabreDAV) | Automated E2E suite |
 | Fastmail | Manually verified |
 
 Should work with any CalDAV server that supports VTODO, including iCloud and Synology.

--- a/README.md
+++ b/README.md
@@ -132,10 +132,15 @@ These notes round-trip to/from CalDAV clients like Thunderbird or Tasks.org.
 
 ## Tested CalDAV servers
 
-- Radicale (E2E test suite)
-- Fastmail
+| Server | Coverage |
+| --- | --- |
+| Radicale | Automated E2E suite |
+| Nextcloud | Automated E2E suite |
+| Vikunja | Automated E2E suite |
+| Baïkal (SabreDAV) | Manually verified (issue #71) |
+| Fastmail | Manually verified |
 
-Should work with any CalDAV server that supports VTODO (Nextcloud, iCloud, Synology, Baikal, etc.).
+Should work with any CalDAV server that supports VTODO, including iCloud and Synology.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tasks CalDAV Sync
 
-Bidirectional sync between [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) and any CalDAV server (Nextcloud, Radicale, Fastmail, iCloud, etc.).
+Bidirectional sync between [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) and any CalDAV server (Nextcloud, Radicale, Baïkal, Fastmail, etc.).
 
 Works with the [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) plugin — syncs task status, dates, priorities, recurrence, tags, and notes as standard VTODO items.
 
@@ -140,7 +140,17 @@ These notes round-trip to/from CalDAV clients like Thunderbird or Tasks.org.
 | Baïkal (SabreDAV) | Automated E2E suite |
 | Fastmail | Manually verified |
 
-Should work with any CalDAV server that supports VTODO, including iCloud and Synology.
+Should work with any CalDAV server that supports VTODO, such as Synology.
+
+### iCloud
+
+iCloud Reminders is **not supported directly** — Apple does not expose it as a
+standard CalDAV/VTODO backend, so sync fails at later steps even with the
+correct server URL ([#74](https://github.com/josecoelho/obsidian-tasks-caldav/issues/74)).
+
+Workaround: sync Obsidian with a standards-compliant CalDAV account (e.g.
+[fruux](https://fruux.com)) and add that same account to the iOS Reminders app.
+Reported working by [@Jane2100117](https://github.com/josecoelho/obsidian-tasks-caldav/issues/74).
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,5 +51,25 @@ services:
       retries: 30
       start_period: 120s
 
+  baikal:
+    image: ckulka/baikal:nginx
+    ports:
+      - "8081:80"
+    environment:
+      # We mount config read-only and seed the DB ourselves, so skip the
+      # image's recursive chown (it fails on the read-only config mount).
+      BAIKAL_SKIP_CHOWN: "1"
+    volumes:
+      - ./test/docker/baikal/baikal.yaml:/seed/baikal.yaml:ro
+      - ./test/docker/baikal/10-seed-db.sh:/docker-entrypoint.d/10-seed-db.sh:ro
+      - baikal-db:/var/www/baikal/Specific/db
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:80/admin/"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
 volumes:
   nextcloud-data:
+  baikal-db:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"test:e2e:radicale": "node scripts/ensure-servers.mjs --only radicale && jest --selectProjects e2e --testPathPatterns='test/e2e/(caldavClient|caldavAdapter|syncRoundTrip)'",
 		"test:e2e:vikunja": "node scripts/ensure-servers.mjs --only vikunja && jest --selectProjects e2e --testPathPatterns='test/e2e/vikunja/'",
 		"test:e2e:nextcloud": "node scripts/ensure-servers.mjs --only nextcloud && jest --selectProjects e2e --testPathPatterns='test/e2e/nextcloud/'",
+		"test:e2e:baikal": "node scripts/ensure-servers.mjs --only baikal && jest --selectProjects e2e --testPathPatterns='test/e2e/baikal/'",
 		"test:watch": "jest --selectProjects unit --watch",
 		"lint": "eslint .",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"

--- a/scripts/ensure-servers.mjs
+++ b/scripts/ensure-servers.mjs
@@ -11,6 +11,7 @@ const SERVERS = [
   { name: 'radicale', url: 'http://localhost:5232/.web/' },
   { name: 'vikunja', url: 'http://localhost:3457/api/v1/info' },
   { name: 'nextcloud', url: 'http://localhost:8080/status.php' },
+  { name: 'baikal', url: 'http://localhost:8081/admin/' },
 ];
 const TIMEOUT_MS = 2000;
 

--- a/src/caldav/calDAVClientDirect.test.ts
+++ b/src/caldav/calDAVClientDirect.test.ts
@@ -282,4 +282,67 @@ END:VCALENDAR</c:calendar-data>
             expect(vtodos[1].data).toContain('todo-2');
         });
     });
+
+    describe('parseHrefForProperty - pure function principal/home discovery', () => {
+        it('should extract href when the property element has predeclared namespace', () => {
+            const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/principals/user/</d:href>
+    <d:propstat>
+      <d:prop>
+        <c:calendar-home-set><d:href>/calendars/user/</d:href></c:calendar-home-set>
+      </d:prop>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+            expect(CalDAVClientDirect.parseHrefForProperty(xml, 'calendar-home-set'))
+                .toBe('/calendars/user/');
+        });
+
+        it('should extract href when SabreDAV/Baïkal declares xmlns inline on the element (issue #71)', () => {
+            const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/dav.php/principals/user/</d:href>
+    <d:propstat>
+      <d:prop>
+        <cal:calendar-home-set xmlns:cal="urn:ietf:params:xml:ns:caldav">
+          <d:href>/dav.php/calendars/user/</d:href>
+        </cal:calendar-home-set>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+            expect(CalDAVClientDirect.parseHrefForProperty(xml, 'calendar-home-set'))
+                .toBe('/dav.php/calendars/user/');
+        });
+
+        it('should extract current-user-principal href with inline xmlns', () => {
+            const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/dav.php/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:current-user-principal xmlns:d="DAV:">
+          <d:href>/dav.php/principals/user/</d:href>
+        </d:current-user-principal>
+      </d:prop>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+            expect(CalDAVClientDirect.parseHrefForProperty(xml, 'current-user-principal'))
+                .toBe('/dav.php/principals/user/');
+        });
+
+        it('should return null when the property is absent', () => {
+            const xml = `<d:multistatus xmlns:d="DAV:"><d:response><d:href>/x/</d:href></d:response></d:multistatus>`;
+            expect(CalDAVClientDirect.parseHrefForProperty(xml, 'calendar-home-set')).toBeNull();
+        });
+    });
 });

--- a/src/caldav/calDAVClientDirect.ts
+++ b/src/caldav/calDAVClientDirect.ts
@@ -120,13 +120,12 @@ export class CalDAVClientDirect implements CalDAVClient {
    * Discover calendar home from principal URL
    */
   private async discoverFromPrincipal(propfindResponse: string, contextUrl: string): Promise<string> {
-    // Extract current-user-principal (handle any namespace prefix or none)
-    const principalMatch = propfindResponse.match(/<(?:\w+:)?current-user-principal>\s*<(?:\w+:)?href>([^<]+)<\/(?:\w+:)?href>/);
-    if (!principalMatch) {
+    const principalHref = CalDAVClientDirect.parseHrefForProperty(propfindResponse, 'current-user-principal');
+    if (!principalHref) {
       throw new Error('Could not find current-user-principal in response');
     }
 
-    let principalUrl = principalMatch[1];
+    let principalUrl = principalHref;
 
     // Make absolute URL if relative
     if (!principalUrl.startsWith('http')) {
@@ -151,13 +150,12 @@ export class CalDAVClientDirect implements CalDAVClient {
       throw new Error(`Failed to get calendar-home-set: ${calendarHomeResponse.status}`);
     }
 
-    // Extract calendar-home-set (handle any namespace prefix or none)
-    const homeMatch = calendarHomeResponse.text.match(/<(?:\w+:)?calendar-home-set>\s*<(?:\w+:)?href>([^<]+)<\/(?:\w+:)?href>/);
-    if (!homeMatch) {
+    const homeHref = CalDAVClientDirect.parseHrefForProperty(calendarHomeResponse.text, 'calendar-home-set');
+    if (!homeHref) {
       throw new Error('Could not find calendar-home-set in principal response');
     }
 
-    let homeUrl = homeMatch[1];
+    let homeUrl = homeHref;
 
     // Make absolute URL if relative
     if (!homeUrl.startsWith('http')) {
@@ -166,6 +164,24 @@ export class CalDAVClientDirect implements CalDAVClient {
     }
 
     return homeUrl;
+  }
+
+  /**
+   * Extract the href of a DAV/CalDAV property from a PROPFIND response.
+   *
+   * Tolerates any namespace prefix and inline `xmlns` declarations on both the
+   * property element and its `href` child. SabreDAV-based servers (Baïkal)
+   * declare the CalDAV namespace inline on `calendar-home-set` rather than at
+   * the document root, which a prefix-only matcher misses (issue #71).
+   *
+   * Returns the raw href string, or null if the property is absent.
+   */
+  static parseHrefForProperty(xmlText: string, property: string): string | null {
+    const tag = `(?:\\w+:)?${property}(?:\\s[^>]*)?`;
+    const href = '(?:\\w+:)?href(?:\\s[^>]*)?';
+    const regex = new RegExp(`<${tag}>\\s*<${href}>([^<]+)<\\/(?:\\w+:)?href>`);
+    const match = xmlText.match(regex);
+    return match ? match[1] : null;
   }
 
   /**

--- a/test/docker/baikal/10-seed-db.sh
+++ b/test/docker/baikal/10-seed-db.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Seed the Baïkal SQLite database on first start so the E2E suite has a
+# ready-to-use "admin" user without going through the web installer.
+# Runs from nginx's /docker-entrypoint.d/ as root before the server starts.
+set -e
+
+DB=/var/www/baikal/Specific/db/db.sqlite
+SCHEMA=/var/www/baikal/Core/Resources/Db/SQLite/db.sql
+CONFIG=/var/www/baikal/config/baikal.yaml
+
+# Baïkal asserts config/baikal.yaml is writable at runtime, so copy it in
+# (owned by nginx) rather than relying on a read-only bind mount.
+cp /seed/baikal.yaml "$CONFIG"
+chown nginx:nginx "$CONFIG"
+chmod 664 "$CONFIG"
+
+if [ -f "$DB" ]; then
+  echo "[baikal-seed] $DB already exists, skipping seed"
+  exit 0
+fi
+
+echo "[baikal-seed] creating $DB"
+php -r '
+$db = new PDO("sqlite:" . $argv[1]);
+$db->exec(file_get_contents($argv[2]));
+$db->exec("INSERT INTO principals (uri, email, displayname) VALUES (\"principals/admin\", \"admin@example.com\", \"admin\")");
+$db->exec("INSERT INTO users (username, digesta1) VALUES (\"admin\", \"142ff212f9ed2f8f8b5e7b96f6929f78\")");
+' "$DB" "$SCHEMA"
+
+chown -R nginx:nginx /var/www/baikal/Specific/db
+chmod 664 "$DB"
+echo "[baikal-seed] done"

--- a/test/docker/baikal/baikal.yaml
+++ b/test/docker/baikal/baikal.yaml
@@ -1,0 +1,17 @@
+# Pre-baked Baïkal config so the container skips the web installer.
+# Used only by the E2E test suite. Admin/DAV password is "admin".
+system:
+  configured_version: 0.10.1
+  timezone: UTC
+  card_enabled: false
+  cal_enabled: true
+  dav_auth_type: Basic
+  admin_passwordhash: 142ff212f9ed2f8f8b5e7b96f6929f78
+  failed_access_message: 'user %u authentication failure for Baikal'
+  auth_realm: BaikalDAV
+  base_uri: ''
+  invite_from: noreply@example.com
+database:
+  backend: sqlite
+  sqlite_file: /var/www/baikal/Specific/db/db.sqlite
+  encryption_key: e2e-test-key

--- a/test/e2e/baikal/baikal.e2e.test.ts
+++ b/test/e2e/baikal/baikal.e2e.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Baïkal (SabreDAV) CalDAV E2E tests.
+ *
+ * Guards issue #71: principal / calendar-home-set discovery against a
+ * SabreDAV-based server, plus a full sync adapter cycle. Duplication and
+ * ETag edge cases are covered by the Nextcloud/Vikunja suites.
+ */
+import { CalDAVClientDirect } from '../../../src/caldav/calDAVClientDirect';
+import { CalDAVAdapter } from '../../../src/sync/caldavAdapter';
+import { diff } from '../../../src/sync/diff';
+import { VTODOMapper } from '../../../src/caldav/vtodoMapper';
+import { CommonTask } from '../../../src/sync/types';
+import { IdMapping } from '../../../src/types';
+import { FetchHttpClient } from '../../helpers/fetchHttpClient';
+import { BAIKAL, createIsolatedCalendar } from '../../helpers/baikalSetup';
+
+jest.setTimeout(60000);
+
+const emptyIdMapping: IdMapping = { taskIdToCaldavUid: {}, caldavUidToTaskId: {} };
+const httpClient = new FetchHttpClient();
+const mapper = new VTODOMapper();
+
+let calendarName: string;
+let clean: () => Promise<void>;
+let cleanup: () => Promise<void>;
+
+function makeClient(): CalDAVClientDirect {
+  return new CalDAVClientDirect(
+    {
+      serverUrl: BAIKAL.davUrl,
+      username: BAIKAL.username,
+      password: BAIKAL.password,
+      calendarName,
+    },
+    httpClient,
+  );
+}
+
+function buildVTODO(uid: string, summary: string, extra: string[] = []): string {
+  const hasStatus = extra.some(l => l.startsWith('STATUS:'));
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//E2E Test//EN',
+    'BEGIN:VTODO',
+    `UID:${uid}`,
+    'DTSTAMP:20250101T000000Z',
+    `SUMMARY:${summary}`,
+    ...(hasStatus ? [] : ['STATUS:NEEDS-ACTION']),
+    ...extra,
+    'END:VTODO',
+    'END:VCALENDAR',
+  ].join('\r\n');
+}
+
+beforeAll(async () => {
+  const cal = await createIsolatedCalendar();
+  calendarName = cal.calendarName;
+  clean = cal.clean;
+  cleanup = cal.cleanup;
+}, 60000);
+
+beforeEach(async () => {
+  await clean();
+});
+
+afterAll(async () => {
+  await cleanup();
+});
+
+describe('Baïkal: principal discovery (issue #71)', () => {
+  it('should discover calendar-home-set and connect against SabreDAV', async () => {
+    const client = makeClient();
+    await client.connect();
+    expect(client.isConnected()).toBe(true);
+  });
+});
+
+describe('Baïkal: VTODO round-trip', () => {
+  it('should create/fetch/update/delete a VTODO', async () => {
+    const client = makeClient();
+    await client.connect();
+
+    const uid = `bk-crud-${Date.now()}`;
+
+    await client.createVTODO(buildVTODO(uid, 'Buy groceries'), uid);
+    let todos = await client.fetchVTODOs();
+    expect(todos).toHaveLength(1);
+    expect(mapper.vtodoToTask(todos[0]).title).toBe('Buy groceries');
+
+    await client.updateVTODO(
+      todos[0],
+      buildVTODO(uid, 'Buy groceries', ['STATUS:COMPLETED', 'PERCENT-COMPLETE:100']),
+    );
+    todos = await client.fetchVTODOs();
+    expect(mapper.vtodoToTask(todos[0]).status).toBe('DONE');
+
+    await client.deleteVTODO(todos[0]);
+    todos = await client.fetchVTODOs();
+    expect(todos).toHaveLength(0);
+  });
+});
+
+describe('Baïkal sync: full adapter cycle', () => {
+  it('should complete a fetch-diff-apply cycle', async () => {
+    const client = makeClient();
+    const caldavAdapter = new CalDAVAdapter(client);
+    await client.connect();
+
+    const uid = `bk-sync-${Date.now()}`;
+    await client.createVTODO(buildVTODO(uid, 'Original title'), uid);
+
+    const vtodos1 = await client.fetchVTODOs();
+    const caldavTasks1 = caldavAdapter.normalize(vtodos1, emptyIdMapping);
+    expect(caldavTasks1).toHaveLength(1);
+
+    const obsTaskId = `obs-sync-${Date.now()}`;
+    const idMapping: IdMapping = {
+      taskIdToCaldavUid: { [obsTaskId]: uid },
+      caldavUidToTaskId: { [uid]: obsTaskId },
+    };
+    const baseline: CommonTask[] = caldavTasks1.map(t => ({
+      ...t,
+      uid: idMapping.caldavUidToTaskId[t.uid] ?? t.uid,
+    }));
+
+    const obsidianTasks: CommonTask[] = baseline.map(t => ({
+      ...t,
+      title: 'Updated from Obsidian',
+    }));
+
+    const vtodos2 = await client.fetchVTODOs();
+    const caldavTasks2 = caldavAdapter.normalize(vtodos2, idMapping);
+    const changeset = diff(obsidianTasks, caldavTasks2, baseline, 'caldav-wins');
+    expect(changeset.toCalDAV).toHaveLength(1);
+    expect(changeset.toCalDAV[0].type).toBe('update');
+
+    await caldavAdapter.applyChanges(changeset.toCalDAV, idMapping);
+
+    const vtodos3 = await client.fetchVTODOs();
+    expect(vtodos3).toHaveLength(1);
+    expect(mapper.vtodoToTask(vtodos3[0]).title).toBe('Updated from Obsidian');
+  });
+});

--- a/test/helpers/baikalSetup.ts
+++ b/test/helpers/baikalSetup.ts
@@ -1,0 +1,103 @@
+import { FetchHttpClient } from './fetchHttpClient';
+import * as crypto from 'crypto';
+
+export const BAIKAL = {
+  baseUrl: 'http://localhost:8081',
+  davUrl: 'http://localhost:8081/dav.php',
+  username: 'admin',
+  password: 'admin',
+} as const;
+
+const http = new FetchHttpClient();
+
+function authHeader(): Record<string, string> {
+  const encoded = Buffer.from(`${BAIKAL.username}:${BAIKAL.password}`).toString('base64');
+  return { Authorization: `Basic ${encoded}` };
+}
+
+function calendarUrl(name: string): string {
+  return `${BAIKAL.davUrl}/calendars/${BAIKAL.username}/${name}/`;
+}
+
+async function createCalendar(name: string): Promise<void> {
+  const resp = await http.request({
+    url: calendarUrl(name),
+    method: 'MKCALENDAR',
+    headers: {
+      ...authHeader(),
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+    body: `<?xml version="1.0" encoding="UTF-8"?>
+<c:mkcalendar xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:set>
+    <d:prop>
+      <d:displayname>${name}</d:displayname>
+      <c:supported-calendar-component-set>
+        <c:comp name="VTODO" />
+      </c:supported-calendar-component-set>
+    </d:prop>
+  </d:set>
+</c:mkcalendar>`,
+  });
+
+  if (resp.status !== 201 && resp.status !== 207) {
+    throw new Error(`MKCALENDAR failed: ${resp.status} ${resp.text}`);
+  }
+}
+
+async function clearCalendarContents(name: string): Promise<void> {
+  const calUrl = calendarUrl(name);
+
+  const listResp = await http.request({
+    url: calUrl,
+    method: 'PROPFIND',
+    headers: {
+      ...authHeader(),
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Depth': '1',
+    },
+    body: `<?xml version="1.0" encoding="UTF-8"?>
+<d:propfind xmlns:d="DAV:">
+  <d:prop><d:getetag /></d:prop>
+</d:propfind>`,
+  });
+
+  if (listResp.status !== 207) return;
+
+  const hrefMatches = [...listResp.text.matchAll(/<(?:\w+:)?href>([^<]+\.ics)<\/(?:\w+:)?href>/g)];
+  for (const match of hrefMatches) {
+    await http.request({
+      url: `${BAIKAL.baseUrl}${match[1]}`,
+      method: 'DELETE',
+      headers: authHeader(),
+    });
+  }
+}
+
+async function deleteCalendar(name: string): Promise<void> {
+  await http.request({
+    url: calendarUrl(name),
+    method: 'DELETE',
+    headers: authHeader(),
+  });
+}
+
+/**
+ * Create an isolated test calendar with a random name.
+ * Returns the calendar name and cleanup functions.
+ */
+export async function createIsolatedCalendar(): Promise<{
+  calendarName: string;
+  clean: () => Promise<void>;
+  cleanup: () => Promise<void>;
+}> {
+  const calendarName = `e2e-${crypto.randomBytes(6).toString('hex')}`;
+  await createCalendar(calendarName);
+  return {
+    calendarName,
+    /** Clear all VTODOs from the calendar (use in beforeEach). */
+    clean: () => clearCalendarContents(calendarName),
+    /** Delete the calendar (use in afterAll). */
+    cleanup: () => deleteCalendar(calendarName),
+  };
+}


### PR DESCRIPTION
Fixes #71

## Problem

Syncing with a Baïkal CalDAV server failed with:

> Server dump failed: Dump failed: Could not find calendar-home-set in principal response

## Root cause

The plugin already sends an explicit PROPFIND body — the failure was in **response parsing**, not the request.

Baïkal/SabreDAV can declare the CalDAV namespace **inline on the element**:

```xml
<cal:calendar-home-set xmlns:cal="urn:ietf:params:xml:ns:caldav">
  <d:href>/dav.php/calendars/user/</d:href>
</cal:calendar-home-set>
```

The old regex `<(?:\w+:)?calendar-home-set>` required `>` immediately after the tag name, so the ` xmlns:cal="..."` attribute made it fail to match. `current-user-principal` was unaffected because it lives in the `DAV:` namespace, which SabreDAV predeclares at the document root — which is why the error pointed only at `calendar-home-set`.

## Fix

Extracted a pure, attribute-tolerant `parseHrefForProperty()` static helper (tolerates inline `xmlns` and any namespace prefix on both the property element and its `href` child), used for both `current-user-principal` and `calendar-home-set` discovery.

## Tests

**Unit** (`calDAVClientDirect.test.ts`) — SabreDAV/Baïkal-style XML with inline `xmlns` (the exact issue #71 shape), predeclared namespace, and the absent-property case. Reproduced as a failing test first (TDD).

**E2E** — new automated Baïkal (SabreDAV) suite (`test/e2e/baikal/`), mirroring the Nextcloud/Vikunja setup, covering principal discovery, a VTODO round-trip, and a full fetch-diff-apply cycle. The container is seeded deterministically (no web installer) via a pre-baked `baikal.yaml` + a `/docker-entrypoint.d` hook that builds the SQLite DB on first start. Wired into `ensure-servers.mjs` and `npm run test:e2e:baikal`.

> Note: the pinned `ckulka/baikal:nginx` (0.10.1) image predeclares `xmlns:cal` at the document root, so the E2E suite validates the full SabreDAV pipeline rather than reproducing the exact inline-`xmlns` serialization — that specific regression is locked down by the unit test.

- `npm run test:unit` — 361 passed
- `npm run test:e2e:baikal` — 3 passed (verified from a clean `docker compose down -v`)
- `npm run lint` / `npm run build` — clean

README's tested-servers list updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)