### PR TITLE
fix(e2e): use real Vikunja healthcheck so docker --wait is meaningful

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,9 @@ services:
       - /db:uid=1000
       - /app/vikunja/files:uid=1000
     healthcheck:
-      test: ["CMD", "/app/vikunja/vikunja", "help"]
+      # `help` exits 0 instantly, before the API/DB is ready; `healthcheck`
+      # actually probes the running API server so `--wait` is meaningful.
+      test: ["CMD", "/app/vikunja/vikunja", "healthcheck"]
       interval: 2s
       timeout: 5s
       retries: 15


### PR DESCRIPTION
## Summary

Fixes an intermittent E2E failure where the first Vikunja CalDAV request returns **HTTP 500** (e.g. `Create VTODO failed: 500` in `vikunjaClient.e2e.test.ts`).

**Root cause:** Vikunja's healthcheck in `docker-compose.yml` was `["CMD", "/app/vikunja/vikunja", "help"]`, which exits 0 the instant the binary runs — before the HTTP API is listening and DB migrations are done. So `docker compose up -d --wait` returned immediately and Jest could start while Vikunja was still migrating → 500 on the first request.

**Fix (one line + comment):** switch the healthcheck to `["CMD", "/app/vikunja/vikunja", "healthcheck"]` — the binary's built-in subcommand that actually probes the running API server. No host-side script changes; keeps relying on `docker compose --wait`. The Vikunja image has no shell/curl/wget, so the binary subcommand is the only viable in-container probe.

## Test Plan

- [x] `docker exec … vikunja healthcheck` → prints `API server is healthy`, exit 0 (probes the real API)
- [x] `docker compose config -q` valid
- [x] Full E2E suite green with the previous (now-reverted) approach: 37/37 — the underlying tests are sound; this PR only changes when `--wait` releases
- [x] Cold-start gating (healthcheck failing while migrating, so `--wait` blocks) intentionally not reproduced locally — would require recreating the shared Vikunja container and disrupting parallel worktrees; CI provisions fresh containers and exercises it

## Notes

Independent of #67 / PR #83. Standalone test-harness reliability fix off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)