### PR TITLE
docs: clarify tag is a both-ways category filter (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ Indented bullet points below a task are synced as the VTODO DESCRIPTION field:
 
 These notes round-trip to/from CalDAV clients like Thunderbird or Tasks.org.
 
+## Troubleshooting
+
+### Sync reports success but nothing changes
+
+The **Tag** setting is a hard filter on **both** sides, not just routing:
+
+- **Obsidian → CalDAV** — only tasks carrying the Obsidian `#tag` are pushed
+- **CalDAV → Obsidian** — only server VTODOs whose `CATEGORIES` include that tag are pulled
+
+If your server tasks have no matching `CATEGORIES`, sync completes successfully but pulls nothing ("No tasks"). To sync everything regardless of category, leave the **Tag** field empty.
+
 ## Known limitations
 
 - **Priority round-trip is lossy** — obsidian-tasks uses emoji-based priorities (⏫🔼🔽) while CalDAV uses numeric PRIORITY (1-9). Obsidian→CalDAV maps correctly, but CalDAV→Obsidian does not write priority emojis back into the task markdown.

--- a/main.ts
+++ b/main.ts
@@ -322,7 +322,7 @@ class CalDAVSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Tag')
-			.setDesc('Tag that routes tasks to this calendar (without #)')
+			.setDesc('Only tasks with this tag are synced, both ways — the Obsidian tag when pushing, the matching server category when pulling. Leave empty to sync all tasks.')
 			.addText(text => text
 				.setPlaceholder('Work')
 				.setValue(calendar.tag)


### PR DESCRIPTION
Closes #77.

## Problem

The in-app **Tag** setting described itself as *"Tag that routes tasks to this calendar (without #)"*. Users read "routes" as Obsidian-only behavior and didn't realize it's a **hard filter on both sides**:

- Obsidian → CalDAV: only tasks with the Obsidian `#tag` are pushed
- CalDAV → Obsidian: only server VTODOs whose `CATEGORIES` include the tag are pulled

When server tasks have no matching category, sync reports success but pulls nothing — the exact symptom in #77.

## Changes

- Reword the settings field description to state the both-ways filter and the empty-to-sync-all escape hatch (`main.ts`).
- Add a README **Troubleshooting** entry for "sync reports success but nothing changes".

Docs/text only — no behavior change, no settings shape change (wdio `data.json` unaffected). Build + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)