### PR TITLE
fix: completion date off by one due to UTC conversion (#43)

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,3 +1,9 @@
+// Pin a deterministic timezone for the whole suite. Set here (jest main
+// process, before worker processes are spawned) so workers inherit it at
+// startup and V8 reads it before any Date is constructed. setupFiles runs
+// too late — the worker's timezone is already cached by then.
+process.env.TZ = 'America/New_York';
+
 const shared = {
   preset: 'ts-jest',
   testEnvironment: 'node',

--- a/src/caldav/vtodoMapper.ts
+++ b/src/caldav/vtodoMapper.ts
@@ -62,7 +62,7 @@ export class VTODOMapper {
 
     // Completed date
     if (task.completedDate) {
-      lines.push(`COMPLETED:${this.formatDateTimeUTC(new Date(task.completedDate))}`);
+      lines.push(`COMPLETED:${this.formatDateTimeUTC(this.toCompletedInstant(task.completedDate))}`);
       lines.push('PERCENT-COMPLETE:100');
     }
 
@@ -337,6 +337,21 @@ export class VTODOMapper {
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');
     return `${year}${month}${day}`;
+  }
+
+  /**
+   * Resolve a CommonTask completedDate to the instant written as COMPLETED.
+   * Obsidian completion is date-only (✅ YYYY-MM-DD) with no time; anchor it
+   * at local noon so the UTC timestamp maps back to the same local calendar
+   * day in any timezone (round-trip safe). A full datetime is already an
+   * instant and is preserved as-is. See issue #43.
+   */
+  private toCompletedInstant(completedDate: string): Date {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(completedDate)) {
+      const [year, month, day] = completedDate.split('-').map(Number);
+      return new Date(year, month - 1, day, 12, 0, 0);
+    }
+    return new Date(completedDate);
   }
 
   /**

--- a/src/sync/caldavAdapter.test.ts
+++ b/src/sync/caldavAdapter.test.ts
@@ -240,6 +240,55 @@ describe('CalDAVAdapter', () => {
     });
   });
 
+  // The suite is pinned to America/New_York (EST = UTC-5 in January) via
+  // jest.config.cjs. January dates avoid DST ambiguity.
+  describe('completedDate timezone handling (#43)', () => {
+    function icalUtcToDate(ical: string): Date {
+      // YYYYMMDDTHHMMSSZ -> Date
+      const iso = `${ical.slice(0, 4)}-${ical.slice(4, 6)}-${ical.slice(6, 8)}T${ical.slice(9, 11)}:${ical.slice(11, 13)}:${ical.slice(13, 15)}Z`;
+      return new Date(iso);
+    }
+
+    function localDateOf(d: Date): string {
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    }
+
+    const doneTask = {
+      uid: 'tz-task',
+      title: 'TZ task',
+      status: 'DONE' as const,
+      dueDate: null,
+      startDate: null,
+      scheduledDate: null,
+      completedDate: '2025-01-15',
+      priority: 'none' as const,
+      tags: [],
+      recurrenceRule: '',
+      body: '',
+    };
+
+    it('reads an externally-completed UTC timestamp as the local date, not the UTC date', () => {
+      // Phone completes the task at 22:00 local on Jan 15; server stores it
+      // in UTC as Jan 16 03:00. The completion happened on Jan 15 locally.
+      const vtodo = makeCalObj('c-ext', 'Done on phone', ['COMPLETED:20250116T030000Z']);
+      expect(adapter.toCommonTask(vtodo, 'id').completedDate).toBe('2025-01-15');
+    });
+
+    it('writes COMPLETED anchored to the local completion date, not UTC midnight', () => {
+      const ics = adapter.fromCommonTask(doneTask, 'uid-1');
+      const match = ics.match(/COMPLETED:(\d{8}T\d{6}Z)/);
+      expect(match).not.toBeNull();
+      // Interpreted back in the user's zone, it must land on Jan 15.
+      expect(localDateOf(icalUtcToDate(match![1]))).toBe('2025-01-15');
+    });
+
+    it('round-trips a date-only completion without shifting the day', () => {
+      const ics = adapter.fromCommonTask(doneTask, 'uid-1');
+      const calObj: CalendarObject = { data: ics, url: 'http://x/uid-1.ics', etag: 'e' };
+      expect(adapter.toCommonTask(calObj, 'uid-1').completedDate).toBe('2025-01-15');
+    });
+  });
+
   describe('applyChanges', () => {
     it('should call create for create changes', async () => {
       const mockCreateVTODO = jest.fn();

--- a/src/sync/caldavAdapter.ts
+++ b/src/sync/caldavAdapter.ts
@@ -50,9 +50,19 @@ export class CalDAVAdapter {
     return {
       ...parsed,
       uid,
-      // Truncate completedDate to date-only (vtodo returns full datetime)
-      completedDate: parsed.completedDate ? parsed.completedDate.split('T')[0] : null,
+      completedDate: parsed.completedDate ? this.toLocalDate(parsed.completedDate) : null,
     };
+  }
+
+  /**
+   * COMPLETED is stored as a UTC datetime, but Obsidian completion is a
+   * date-only value in the user's local zone. Convert the instant to the
+   * user's local calendar date so a task completed just after local midnight
+   * is not recorded as the previous day. See issue #43.
+   */
+  private toLocalDate(isoDateTime: string): string {
+    const d = new Date(isoDateTime);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
   }
 
   /**

--- a/test/wdio/specs/completionTimezone.e2e.ts
+++ b/test/wdio/specs/completionTimezone.e2e.ts
@@ -1,0 +1,58 @@
+import { browser } from '@wdio/globals';
+import { createIsolatedCalendar } from '../../helpers/radicaleSetup';
+import { useCalendar, syncNow } from '../helpers/pluginConfig';
+import { buildVtodoIcs, putVtodo } from '../helpers/serverVtodo';
+
+// Regression for issue #43, exercised in the real Obsidian/Electron process.
+// The suite is pinned to Pacific/Auckland (UTC+13 in January) via wdio.conf.mts.
+//
+// A task completed late on the previous UTC day is still "today" locally.
+// COMPLETED:20250114T220000Z == 2025-01-15 11:00 in Auckland, so the Obsidian
+// task must show ✅ 2025-01-15 (local date), not ✅ 2025-01-14 (the UTC date
+// that the old split('T')[0] produced).
+describe('completion date timezone (#43)', function () {
+  let calendarName: string;
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeEach(async function () {
+    const cal = await createIsolatedCalendar();
+    calendarName = cal.calendarName;
+    cleanup = cal.cleanup;
+    await useCalendar(calendarName);
+  });
+
+  afterEach(async function () { await cleanup?.(); });
+
+  it('renders an externally-completed task with the local date, not the UTC date', async function () {
+    // Guard: the fix is only meaningfully exercised if Electron honors the
+    // pinned non-UTC zone. If it doesn't, fail loudly rather than vacuously.
+    const offsetMinutes = await browser.executeObsidian(() => new Date().getTimezoneOffset());
+    if (offsetMinutes === 0) {
+      throw new Error('Electron is running in UTC; cannot exercise the #43 timezone bug. Set TZ.');
+    }
+
+    const uid = `wdio-tz-${Date.now()}`;
+    const summary = `Completed abroad ${Date.now()}`;
+    const ics = buildVtodoIcs(uid, summary, {
+      STATUS: 'COMPLETED',
+      COMPLETED: '20250114T220000Z',
+    });
+    await putVtodo(calendarName, uid, ics);
+
+    await syncNow();
+
+    await browser.waitUntil(async () => {
+      const inbox = await browser.executeObsidian(async ({ app }) => {
+        const f = app.vault.getAbstractFileByPath('Inbox.md');
+        return f ? app.vault.read(f as any) : '';
+      });
+      return inbox.includes(summary) && inbox.includes('✅ 2025-01-15');
+    }, { timeout: 15000, interval: 500, timeoutMsg: `task "${summary}" not written with ✅ 2025-01-15` });
+
+    const inbox = await browser.executeObsidian(async ({ app }) => {
+      const f = app.vault.getAbstractFileByPath('Inbox.md');
+      return f ? app.vault.read(f as any) : '';
+    });
+    expect(inbox).not.toContain('✅ 2025-01-14');
+  });
+});

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -1,5 +1,11 @@
 import path from 'node:path';
 
+// Pin a non-UTC zone so completion-date timezone behavior (issue #43) is
+// exercised deterministically in the real Obsidian/Electron process. Auckland
+// is UTC+13 in January, far from UTC, so a UTC COMPLETED on the previous day
+// must still render as today's local date. Overridable via the TZ env var.
+process.env.TZ = process.env.TZ || 'Pacific/Auckland';
+
 export const config: WebdriverIO.Config = {
   runner: 'local',
   framework: 'mocha',


### PR DESCRIPTION
Fixes #43.

## Root cause (deeper than the issue described)

The date-only ↔ UTC-datetime mismatch was handled inconsistently on **both** sides:

- **Read** (`caldavAdapter.ts`): `parsed.completedDate.split('T')[0]` took the **UTC** date. A task completed just after local midnight (positive UTC offsets) showed yesterday — the reported symptom.
- **Write** (`vtodoMapper.ts`): `new Date('2025-02-17')` parses as **UTC midnight**, so we stored `COMPLETED:20250217T000000Z`. Other CalDAV clients in **negative** offsets saw the previous day, and the issue's suggested read-only fix would have made sync **flap** every cycle for those users (the two bugs were cancelling each other).

## Fix

Symmetric handling:

- **Read**: convert the UTC instant to the user's **local calendar date** (`toLocalDate`).
- **Write**: anchor a date-only completion at **local noon** before formatting as UTC (`toCompletedInstant`); full datetimes are preserved as-is. Noon anchoring keeps the round-trip stable in every timezone.

## Test infrastructure

The Jest worker locks its timezone to the machine zone before `setupFiles` runs, and mid-test `process.env.TZ` reassignment silently does nothing. The suite is now pinned to `America/New_York` (EST, no January DST) in `jest.config.cjs` — the main process, before workers spawn — so date/time tests are deterministic on any machine/CI.

## Tests

TDD: failing tests first (read off-by-one for positive offsets; write off-by-one for negative offsets), then the symmetric fix, plus a round-trip regression guard.

## Verification

- `npm test`: 416/416 passed (unit + e2e against real CalDAV servers), coverage thresholds met
- `npm run lint`: clean
- `tsc -noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)