### PR TITLE
fix(release): PR-based release script + README community-directory update

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ Works with the [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian
 
 ## Installation
 
-### From Community Plugins
+### From Community Plugins (recommended)
 
-Not yet available — [waiting for review](https://github.com/obsidianmd/obsidian-releases/pull/10183).
+Available in the [Obsidian community plugin directory](https://community.obsidian.md/plugins/tasks-caldav-sync):
 
-### Using BRAT (recommended)
+1. Open Settings → Community plugins → **Browse**
+2. Search for "Tasks CalDAV Sync"
+3. Click **Install**, then **Enable**
+
+### Using BRAT (for beta releases)
 
 1. Install the [BRAT plugin](https://tfthacker.com/brat-quick-guide)
 2. Open BRAT settings → **Add Beta Plugin**

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Release script for Tasks CalDAV Sync Obsidian plugin
+# Release script for Tasks CalDAV Sync Obsidian plugin — PR-based.
+#
+# We cannot push directly to master, so releasing is two-phase:
+#
+#   Phase 1 (versions != <tag>): branch off master, bump version, push the
+#           branch, open a PR, then stop. You review & merge the PR.
+#   Phase 2 (re-run after merge, versions == <tag>): build, tag HEAD, and
+#           publish the GitHub release. (Pushing a tag is not a branch push,
+#           so it does not violate master branch protection.)
+#
 # Usage:
-#   ./scripts/release.sh 1.0.0              # create or update release
-#   ./scripts/release.sh 1.1.0 --new        # create new release (fails if tag exists)
-#   ./scripts/release.sh 1.1.0 --dry-run    # show what would happen without making changes
-#   ./scripts/release.sh 1.1.0 --new --dry-run
+#   ./scripts/release.sh 1.1.7              # phase 1, then (after merge) phase 2
+#   ./scripts/release.sh 1.1.7 --new        # fail if tag already exists
+#   ./scripts/release.sh 1.1.7 --dry-run    # show what would happen, change nothing
 
 TAG=""
 NEW_ONLY=false
@@ -25,6 +33,10 @@ done
 if [[ -z "$TAG" ]]; then
   echo "Usage: release.sh <tag> [--new] [--dry-run]"
   echo ""
+  echo "Two-phase, PR-based release:"
+  echo "  1. First run (versions != <tag>): opens a version-bump PR. Merge it."
+  echo "  2. Re-run after merge (versions == <tag>): tags HEAD and publishes."
+  echo ""
   echo "Options:"
   echo "  --new       Fail if tag already exists (prevents overwriting)"
   echo "  --dry-run   Show what would happen without making any changes"
@@ -39,22 +51,28 @@ run() {
   fi
 }
 
+ensure_master_clean() {
+  local branch
+  branch=$(git branch --show-current)
+  if [[ "$branch" != "master" ]]; then
+    echo "Error: must be on master branch (currently on $branch)"
+    exit 1
+  fi
+  if [[ "$DRY_RUN" == false && -n $(git status --porcelain --ignore-submodules) ]]; then
+    echo "Error: working tree is not clean. Commit or stash changes first."
+    exit 1
+  fi
+}
+
+build_and_verify() {
+  run npm run build
+  run npm run lint
+  run npx jest --config jest.config.cjs --selectProjects unit
+}
+
 echo "=== Release $TAG ==="
 [[ "$DRY_RUN" == true ]] && echo "(dry run mode — no changes will be made)"
 echo ""
-
-# Ensure we're on master
-BRANCH=$(git branch --show-current)
-if [[ "$BRANCH" != "master" ]]; then
-  echo "Error: must be on master branch (currently on $BRANCH)"
-  exit 1
-fi
-
-# Ensure working tree is clean (skip in dry-run since we won't commit)
-if [[ "$DRY_RUN" == false && -n $(git status --porcelain --ignore-submodules) ]]; then
-  echo "Error: working tree is not clean. Commit or stash changes first."
-  exit 1
-fi
 
 # Check if tag already exists
 TAG_EXISTS=$(git tag -l "$TAG")
@@ -64,42 +82,44 @@ if [[ -n "$TAG_EXISTS" && "$NEW_ONLY" == true ]]; then
   exit 1
 fi
 
-# Build & verify
-echo "--- Build & verify ---"
-run npm run build
-run npm run lint
-run npx jest --config jest.config.cjs --selectProjects unit
-
-# Check versions
-echo ""
-echo "--- Version check ---"
+# Read current versions
 MANIFEST_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('manifest.json','utf8')).version)")
 PACKAGE_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")
 MIN_APP_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('manifest.json','utf8')).minAppVersion)")
 
-echo "Target tag:       $TAG"
-echo "manifest.json:    $MANIFEST_VERSION"
-echo "package.json:     $PACKAGE_VERSION"
-echo "minAppVersion:    $MIN_APP_VERSION"
-
 if [[ "$MANIFEST_VERSION" != "$TAG" || "$PACKAGE_VERSION" != "$TAG" ]]; then
+  # ----------------------------------------------------------------------
+  # Phase 1 — open a version-bump PR (no direct push to master)
+  # ----------------------------------------------------------------------
+  echo "--- Phase 1: version-bump PR ---"
+  echo "manifest.json: $MANIFEST_VERSION   package.json: $PACKAGE_VERSION   ->   $TAG"
   echo ""
-  echo "Version mismatch — updating to $TAG..."
 
+  ensure_master_clean
+  run git fetch origin
+  run git pull --ff-only origin master
+
+  RELEASE_BRANCH="release/$TAG"
+  run git switch -c "$RELEASE_BRANCH"
+
+  echo ""
+  echo "--- Build & verify ---"
+  build_and_verify
+
+  echo ""
+  echo "--- Bump version to $TAG ---"
   run node -e "
     const fs = require('fs');
     const m = JSON.parse(fs.readFileSync('manifest.json','utf8'));
     m.version = '$TAG';
     fs.writeFileSync('manifest.json', JSON.stringify(m, null, '\t') + '\n');
   "
-
   run node -e "
     const fs = require('fs');
     const p = JSON.parse(fs.readFileSync('package.json','utf8'));
     p.version = '$TAG';
     fs.writeFileSync('package.json', JSON.stringify(p, null, '\t') + '\n');
   "
-
   run node -e "
     const fs = require('fs');
     const m = JSON.parse(fs.readFileSync('manifest.json','utf8'));
@@ -110,16 +130,40 @@ if [[ "$MANIFEST_VERSION" != "$TAG" || "$PACKAGE_VERSION" != "$TAG" ]]; then
 
   run git add manifest.json package.json versions.json
   run git commit -m "chore: bump version to $TAG"
-  run git push origin master
+  run git push -u origin "$RELEASE_BRANCH"
+  run gh pr create --base master --head "$RELEASE_BRANCH" \
+    --title "chore: bump version to $TAG" \
+    --body "Version bump for release $TAG.
 
-  # Rebuild with updated manifest
-  echo "Rebuilding with updated version..."
-  run npm run build
-else
-  echo "Versions already match $TAG — no bump needed."
+Merge this, then re-run \`./scripts/release.sh $TAG\` from an up-to-date master to tag HEAD and publish the GitHub release."
+
+  echo ""
+  echo "Phase 1 complete. Next:"
+  echo "  1. Review & merge the PR above."
+  echo "  2. git switch master && git pull --ff-only origin master"
+  echo "  3. Re-run: ./scripts/release.sh $TAG   (tags & publishes)"
+  exit 0
 fi
 
-# Tag
+# ----------------------------------------------------------------------
+# Phase 2 — versions match: tag HEAD + publish the GitHub release
+# ----------------------------------------------------------------------
+echo "--- Phase 2: tag & publish ---"
+ensure_master_clean
+run git fetch origin
+run git pull --ff-only origin master
+
+echo ""
+echo "Target tag:       $TAG"
+echo "manifest.json:    $MANIFEST_VERSION"
+echo "package.json:     $PACKAGE_VERSION"
+echo "minAppVersion:    $MIN_APP_VERSION"
+echo "Versions match $TAG — no bump needed."
+
+echo ""
+echo "--- Build & verify ---"
+build_and_verify
+
 echo ""
 echo "--- Tag ---"
 if [[ -n "$TAG_EXISTS" ]]; then
@@ -132,7 +176,6 @@ else
   run git push origin "$TAG"
 fi
 
-# Release
 echo ""
 echo "--- GitHub release ---"
 RELEASE_EXISTS=$(gh release view "$TAG" --json tagName 2>/dev/null || echo "")


### PR DESCRIPTION
## Why

`./scripts/release.sh` pushed commits straight to `master` (version bump on lines 112-113 of the old script). We can't push directly to master, so the release flow violated branch policy. CI never caught the lint issue that surfaced this because CI runs on a fresh checkout with no `.claude/worktrees/` copies.

## Changes

**`scripts/release.sh` — now two-phase, PR-based:**
- **Phase 1** (versions ≠ `<tag>`): fast-forward master, branch to `release/<tag>`, build & verify, bump `manifest.json`/`package.json`/`versions.json`, push the branch, open a PR, then stop.
- **Phase 2** (re-run after merge, versions == `<tag>`): fast-forward master, build & verify, tag HEAD, publish/refresh the GitHub release.
- Pushing a **tag** is not a branch push, so phase 2 respects master branch protection.
- `--new` / `--dry-run` semantics preserved.

**`README.md`:** plugin is [live in the community directory](https://community.obsidian.md/plugins/tasks-caldav-sync). "From Community Plugins" updated from "waiting for review" and made the recommended path; BRAT demoted to beta-release usage.

## Note

`1.1.7` is already released (published before this policy was raised). This PR fixes the process so future releases go through review. The companion eslint `.claude/` ignore fix (`aa41f8b`) is already on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)