### PR TITLE
fix(release): make the release flow PR-based

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,62 @@
+name: Tag release on version bump
+
+# When a release/<version> PR merges to master, manifest.json's version
+# changes. This workflow turns that into a GitHub release: it creates the
+# tag/release as a pre-release, then calls release.yml to build, attest,
+# upload, and promote.
+#
+# It calls release.yml directly (workflow_call) rather than relying on
+# release.yml's `release: published` trigger, because a release created
+# with GITHUB_TOKEN does not trigger further workflow runs.
+on:
+  push:
+    branches: [master]
+    paths:
+      - manifest.json
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      created: ${{ steps.create.outputs.created }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - id: version
+        run: echo "version=$(node -p "require('./manifest.json').version")" >> "$GITHUB_OUTPUT"
+
+      - id: create
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists; nothing to do."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            gh release create "$VERSION" \
+              --target master \
+              --title "$VERSION" \
+              --generate-notes \
+              --prerelease
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: create-release
+    if: needs.create-release.outputs.created == 'true'
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.create-release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,22 @@
 name: Release
 
-# Publish a release in the GitHub UI (tag = version, target = master).
-# This workflow then builds from that tag, attaches a build-provenance
-# attestation, and uploads the assets. The released main.js is therefore
-# always CI-built and reproducible — never a local build.
+# Builds from the release tag (tag = version, target = master), attaches a
+# build-provenance attestation, uploads the assets, and promotes the
+# pre-release to latest. The released main.js is therefore always CI-built
+# and reproducible — never a local build.
+#
+# Triggered two ways:
+#   - workflow_call from release-tag.yml (the normal PR-based flow)
+#   - release: published, for a release created manually in the GitHub UI
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag to build and publish
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,10 +26,12 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ inputs.tag || github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -29,13 +41,11 @@ jobs:
       - run: npm ci
 
       - name: Verify tag matches manifest version
-        env:
-          TAG: ${{ github.event.release.tag_name }}
         run: |
           MANIFEST_VERSION="$(node -p "require('./manifest.json').version")"
           if [ "$MANIFEST_VERSION" != "$TAG" ]; then
             echo "Release tag $TAG does not match manifest.json version $MANIFEST_VERSION." >&2
-            echo "Run 'npm run release $TAG' on master before publishing the release." >&2
+            echo "The release/<version> PR must be merged to master before the release is created." >&2
             exit 1
           fi
 
@@ -53,11 +63,9 @@ jobs:
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name }}
         run: gh release upload "$TAG" --clobber main.js manifest.json styles.css
 
       - name: Promote to latest stable release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name }}
         run: gh release edit "$TAG" --prerelease=false --latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,18 +155,34 @@ Releases are built and signed in CI — never from a local machine. The
 released `main.js` must be reproducible by Obsidian's verifier, so the
 binary always comes from `.github/workflows/release.yml`.
 
+`master` is branch-protected (PR required, signed commits, Copilot
+review) with no bypass actors. The release flow works **with** those
+rules — it never pushes to master.
+
 Process — one command:
-1. `npm run release <version>` on master — bumps `manifest.json`,
-   `package.json`, `versions.json`, runs preflight (lint/typecheck/unit),
-   commits, pushes master, and creates the GitHub release as a
-   **pre-release** (requires the authenticated `gh` CLI).
-2. The `release` workflow (trigger: `release: published`) checks out the
-   tag, verifies tag == `manifest.json` version, builds, generates a
-   build-provenance attestation, uploads `main.js`/`manifest.json`/
-   `styles.css`, then promotes the pre-release to the latest stable
-   release.
+1. `npm run release <version>` on master — creates a `release/<version>`
+   branch, bumps `manifest.json`/`package.json`/`versions.json`, runs
+   preflight (lint/typecheck/unit), commits, pushes the branch, opens a
+   PR, and enables auto-merge (squash). Requires the authenticated `gh`
+   CLI. It pushes **nothing** to master and builds nothing locally.
+2. The PR merges to master once required checks/review pass. GitHub
+   signs the squash commit (satisfies `required_signatures`).
+3. `release-tag.yml` (trigger: push to master touching `manifest.json`)
+   reads the new version, and if no release exists for it, creates the
+   GitHub release as a **pre-release**, then calls `release.yml`.
+4. `release.yml` (reusable; also kept on `release: published` for manual
+   UI releases) checks out the tag, verifies tag == `manifest.json`
+   version, builds, generates a build-provenance attestation, uploads
+   `main.js`/`manifest.json`/`styles.css`, then promotes the pre-release
+   to the latest stable release.
 
 Notes:
+- `release-tag.yml` calls `release.yml` via `workflow_call`, not via the
+  `release: published` event — a release created with `GITHUB_TOKEN`
+  does not trigger further workflow runs.
+- Merge the release PR with **squash** (auto-merge uses squash). A
+  rebase merge would replay unsigned local commits onto master and fail
+  `required_signatures`.
 - Tag matches `manifest.json` version exactly (no `v` prefix).
 - It ships as a pre-release until CI finishes, so there is never a
   public window with missing assets (Obsidian ignores pre-releases).

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -2,15 +2,21 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 
-// One-command release. Bumps the version files, commits, pushes master,
-// and creates the GitHub release as a pre-release. It builds and uploads
-// NOTHING locally — the `release` workflow (trigger: release: published)
-// builds, attests, uploads the assets, and then promotes the pre-release
-// to the latest stable release. Obsidian ignores pre-releases, so there
-// is never a public window with missing assets.
+// One-command release. master is branch-protected (PR required, signed
+// commits, Copilot review) with no bypass, so this script never pushes
+// to master. It bumps the version files on a release/<version> branch,
+// opens a PR, and enables auto-merge. The rest is fully in CI:
 //
-//   npm run release 1.1.8                 bump -> push -> create release
-//   npm run release 1.1.8 -- --skip-checks   skip the local preflight
+//   PR merges to master (GitHub signs the squash commit)
+//     -> release-tag.yml sees the manifest.json version change,
+//        creates the GitHub release as a pre-release, and calls
+//        release.yml to build, attest, upload, and promote.
+//
+// It builds and uploads NOTHING locally. Obsidian ignores pre-releases,
+// so there is never a public window with missing assets.
+//
+//   npm run release 1.1.8                  bump -> PR -> auto-merge
+//   npm run release 1.1.8 -- --skip-checks  skip the local preflight
 //
 // Requires the `gh` CLI, authenticated.
 
@@ -23,23 +29,42 @@ if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
 	process.exit(1);
 }
 
+const branch = `release/${version}`;
 const git = (...gitArgs) => execFileSync('git', gitArgs, { encoding: 'utf8' }).trim();
+const fail = (message) => {
+	console.error(`Error: ${message}`);
+	process.exit(1);
+};
 
 if (git('branch', '--show-current') !== 'master') {
-	console.error('Error: must be on master.');
-	process.exit(1);
+	fail('must be on master.');
 }
 if (git('status', '--porcelain', '--ignore-submodules')) {
-	console.error('Error: working tree is not clean. Commit or stash first.');
-	process.exit(1);
+	fail('working tree is not clean. Commit or stash first.');
+}
+
+git('fetch', 'origin', 'master', '--quiet');
+if (git('rev-parse', 'HEAD') !== git('rev-parse', 'origin/master')) {
+	fail('local master is not in sync with origin/master. Reconcile (git pull / reset) before releasing.');
 }
 
 try {
 	execFileSync('gh', ['release', 'view', version], { stdio: 'ignore' });
-	console.error(`Error: release ${version} already exists. Bump to a new version.`);
-	process.exit(1);
+	fail(`release ${version} already exists. Bump to a new version.`);
 } catch {
 	// No existing release — expected.
+}
+
+const branchExists = (ref) => {
+	try {
+		execFileSync('git', ['rev-parse', '--verify', '--quiet', ref], { stdio: 'ignore' });
+		return true;
+	} catch {
+		return false;
+	}
+};
+if (branchExists(branch) || branchExists(`origin/${branch}`)) {
+	fail(`branch ${branch} already exists. Delete it or pick a new version.`);
 }
 
 const readJson = (file) => JSON.parse(readFileSync(file, 'utf8'));
@@ -52,6 +77,8 @@ const versions = readJson('versions.json');
 manifest.version = version;
 pkg.version = version;
 versions[version] = manifest.minAppVersion;
+
+git('checkout', '-b', branch);
 
 writeJson('manifest.json', manifest);
 writeJson('package.json', pkg);
@@ -67,16 +94,36 @@ if (!skipChecks) {
 
 git('add', 'manifest.json', 'package.json', 'versions.json');
 git('commit', '-m', `chore: bump version to ${version}`);
-git('push', 'origin', 'master');
+git('push', '-u', 'origin', branch);
 
-execFileSync('gh', [
-	'release', 'create', version,
-	'--target', 'master',
-	'--title', version,
-	'--generate-notes',
-	'--prerelease',
-], { stdio: 'inherit' });
+const prUrl = execFileSync('gh', [
+	'pr', 'create',
+	'--base', 'master',
+	'--head', branch,
+	'--title', `chore: release ${version}`,
+	'--body',
+	`Version bump to \`${version}\`.\n\n` +
+		'When this merges, `release-tag.yml` creates the GitHub release ' +
+		'(pre-release) and `release.yml` builds, attests, uploads the ' +
+		'assets, and promotes it to the latest stable release.',
+], { encoding: 'utf8' }).trim();
 
-console.log(`\nRelease ${version} created as a pre-release.`);
-console.log('The release workflow is now building, attesting, and uploading');
-console.log('assets, then promoting it to the latest stable release.');
+git('checkout', 'master');
+
+let autoMerge = true;
+try {
+	// Squash so master gets a single GitHub-signed commit (required_signatures).
+	execFileSync('gh', ['pr', 'merge', prUrl, '--auto', '--squash'], { stdio: 'inherit' });
+} catch {
+	autoMerge = false;
+}
+
+console.log(`\nRelease PR for ${version} opened: ${prUrl}`);
+if (autoMerge) {
+	console.log('Auto-merge (squash) is enabled — it merges once required');
+	console.log('checks and review pass, then CI creates and publishes the release.');
+} else {
+	console.log('Could not enable auto-merge (repo setting may be off).');
+	console.log('Merge the PR with "Squash and merge" once checks/review pass;');
+	console.log('CI then creates and publishes the release automatically.');
+}


### PR DESCRIPTION
\`master\` is branch-protected (PR required, signed commits, Copilot review) with no bypass actors. The release script used to \`git push origin master\` directly, which the ruleset now rejects.

## Changes
- **\`scripts/prepare-release.mjs\`** — bumps version files on a \`release/<version>\` branch, opens a PR, and enables squash auto-merge. Never pushes to master; builds nothing locally.
- **\`.github/workflows/release-tag.yml\`** (new) — on the bump landing on master (push touching \`manifest.json\`), creates the GitHub release as a pre-release, then calls \`release.yml\`. Calls it via \`workflow_call\` rather than the \`release: published\` event, because a release created with \`GITHUB_TOKEN\` does not trigger further workflow runs.
- **\`.github/workflows/release.yml\`** — now a reusable workflow (\`workflow_call\` with a \`tag\` input) while keeping the \`release: published\` trigger for manual UI releases.
- **\`CLAUDE.md\`** — documents the new flow.

## Notes
- Merge with **squash** (auto-merge uses squash) so master gets a single GitHub-signed commit, satisfying \`required_signatures\`. A rebase merge would replay unsigned local commits and fail.
- This PR does not touch the \`manifest.json\` version, so \`release-tag.yml\` will not fire on its merge.
- The pending \`1.2.0\` release is in PR #__ (\`release/1.2.0\`); merge **this** PR first so \`release-tag.yml\` exists before that one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)