### PR TITLE
fix: preserve obsidian-tasks global filter tag on writeback (#93)

### DIFF
--- a/src/sync/obsidianAdapter.test.ts
+++ b/src/sync/obsidianAdapter.test.ts
@@ -38,6 +38,7 @@ const dummyWrapper = {
   getTaskId: jest.fn(),
   getToggleCommand: jest.fn().mockReturnValue(null),
   getConfiguredFormat: jest.fn().mockResolvedValue('emoji'),
+  getGlobalFilter: jest.fn().mockResolvedValue(''),
 } as unknown as ObsidianTasksWrapper;
 
 const defaultSettings: ObsidianSyncSettings = {

--- a/src/sync/obsidianAdapter.test.ts
+++ b/src/sync/obsidianAdapter.test.ts
@@ -37,8 +37,7 @@ const dummyWrapper = {
   initialize: jest.fn().mockReturnValue(true),
   getTaskId: jest.fn(),
   getToggleCommand: jest.fn().mockReturnValue(null),
-  getConfiguredFormat: jest.fn().mockResolvedValue('emoji'),
-  getGlobalFilter: jest.fn().mockResolvedValue(''),
+  getTasksPluginConfig: jest.fn().mockResolvedValue({ format: 'emoji', globalFilter: '' }),
 } as unknown as ObsidianTasksWrapper;
 
 const defaultSettings: ObsidianSyncSettings = {
@@ -231,7 +230,7 @@ describe('ObsidianAdapter', () => {
       const createTask = jest.fn().mockImplementation((markdown: string) => { written = markdown; return Promise.resolve(); });
       const wrapper = {
         ...dummyWrapper, createTask,
-        getConfiguredFormat: jest.fn().mockResolvedValue('dataview'),
+        getTasksPluginConfig: jest.fn().mockResolvedValue({ format: 'dataview', globalFilter: '' }),
       } as unknown as ObsidianTasksWrapper;
       const adapter = new ObsidianAdapter(wrapper, { syncTag: 'sync', newTasksDestination: 'Inbox.md' });
 
@@ -246,7 +245,7 @@ describe('ObsidianAdapter', () => {
       const createTask = jest.fn().mockImplementation((markdown: string) => { written = markdown; return Promise.resolve(); });
       const wrapper = {
         ...dummyWrapper, createTask,
-        getConfiguredFormat: jest.fn().mockResolvedValue('emoji'),
+        getTasksPluginConfig: jest.fn().mockResolvedValue({ format: 'emoji', globalFilter: '' }),
       } as unknown as ObsidianTasksWrapper;
       const adapter = new ObsidianAdapter(wrapper, { syncTag: 'sync', newTasksDestination: 'Inbox.md' });
 
@@ -264,7 +263,7 @@ describe('ObsidianAdapter', () => {
         ...dummyWrapper,
         findTaskById: jest.fn().mockReturnValue(existing),
         updateTaskInVault,
-        getConfiguredFormat: jest.fn().mockResolvedValue('dataview'),
+        getTasksPluginConfig: jest.fn().mockResolvedValue({ format: 'dataview', globalFilter: '' }),
       } as unknown as ObsidianTasksWrapper;
       const adapter = new ObsidianAdapter(wrapper, { syncTag: 'sync', newTasksDestination: 'Inbox.md' });
 
@@ -283,7 +282,7 @@ describe('ObsidianAdapter', () => {
         ...dummyWrapper,
         extractId: jest.fn().mockReturnValue(null),
         updateTaskInVault,
-        getConfiguredFormat: jest.fn().mockResolvedValue('dataview'),
+        getTasksPluginConfig: jest.fn().mockResolvedValue({ format: 'dataview', globalFilter: '' }),
       } as unknown as ObsidianTasksWrapper;
       const adapter = new ObsidianAdapter(wrapper, { syncTag: 'sync', newTasksDestination: 'Inbox.md' });
 

--- a/src/sync/obsidianAdapter.ts
+++ b/src/sync/obsidianAdapter.ts
@@ -103,10 +103,7 @@ export class ObsidianAdapter {
 		}> = [];
 
 		// used by the create and update cases; the complete case delegates serialisation to obsidian-tasks
-		const [format, globalFilter] = await Promise.all([
-			this.wrapper.getConfiguredFormat(),
-			this.wrapper.getGlobalFilter(),
-		]);
+		const { format, globalFilter } = await this.wrapper.getTasksPluginConfig();
 		for (const change of changes) {
 			try {
 				switch (change.type) {
@@ -213,10 +210,7 @@ export class ObsidianAdapter {
 	 * Only called after sync succeeds, so IDs are only persisted when sync completes.
 	 */
 	async writeBackIds(obsidianTasks: CommonTask[]): Promise<void> {
-		const [format, globalFilter] = await Promise.all([
-			this.wrapper.getConfiguredFormat(),
-			this.wrapper.getGlobalFilter(),
-		]);
+		const { format, globalFilter } = await this.wrapper.getTasksPluginConfig();
 		for (const task of obsidianTasks) {
 			const original = this.tasksById.get(task.uid);
 			if (!original) continue;

--- a/src/sync/obsidianAdapter.ts
+++ b/src/sync/obsidianAdapter.ts
@@ -103,7 +103,10 @@ export class ObsidianAdapter {
 		}> = [];
 
 		// used by the create and update cases; the complete case delegates serialisation to obsidian-tasks
-		const format = await this.wrapper.getConfiguredFormat();
+		const [format, globalFilter] = await Promise.all([
+			this.wrapper.getConfiguredFormat(),
+			this.wrapper.getGlobalFilter(),
+		]);
 		for (const change of changes) {
 			try {
 				switch (change.type) {
@@ -117,6 +120,7 @@ export class ObsidianAdapter {
 							taskWithId,
 							this.settings.syncTag,
 							format,
+							globalFilter,
 						);
 
 						await this.wrapper.createTask(
@@ -142,6 +146,7 @@ export class ObsidianAdapter {
 							change.task,
 							this.settings.syncTag,
 							format,
+							globalFilter,
 						);
 						await this.wrapper.updateTaskInVault(
 							existingTask,
@@ -208,7 +213,10 @@ export class ObsidianAdapter {
 	 * Only called after sync succeeds, so IDs are only persisted when sync completes.
 	 */
 	async writeBackIds(obsidianTasks: CommonTask[]): Promise<void> {
-		const format = await this.wrapper.getConfiguredFormat();
+		const [format, globalFilter] = await Promise.all([
+			this.wrapper.getConfiguredFormat(),
+			this.wrapper.getGlobalFilter(),
+		]);
 		for (const task of obsidianTasks) {
 			const original = this.tasksById.get(task.uid);
 			if (!original) continue;
@@ -220,6 +228,7 @@ export class ObsidianAdapter {
 					task,
 					this.settings.syncTag,
 					format,
+					globalFilter,
 				);
 				await this.wrapper.updateTaskInVault(original, markdown);
 			} catch (error) {

--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -116,6 +116,7 @@ jest.mock('../tasks/obsidianTasksWrapper', () => ({
     extractId: mockExtractId,
     getToggleCommand: mockGetToggleCommand,
     getConfiguredFormat: jest.fn().mockResolvedValue('emoji'),
+    getGlobalFilter: jest.fn().mockResolvedValue(''),
   })),
 }));
 

--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -115,8 +115,7 @@ jest.mock('../tasks/obsidianTasksWrapper', () => ({
     filterByTag: mockFilterByTag,
     extractId: mockExtractId,
     getToggleCommand: mockGetToggleCommand,
-    getConfiguredFormat: jest.fn().mockResolvedValue('emoji'),
-    getGlobalFilter: jest.fn().mockResolvedValue(''),
+    getTasksPluginConfig: jest.fn().mockResolvedValue({ format: 'emoji', globalFilter: '' }),
   })),
 }));
 

--- a/src/tasks/obsidianMapper.test.ts
+++ b/src/tasks/obsidianMapper.test.ts
@@ -269,4 +269,61 @@ describe('ObsidianMapper', () => {
     });
   });
 
+  describe('toMarkdown — global filter', () => {
+    const baseTask: CommonTask = {
+      uid: 'test-id', title: 'Test task', status: 'TODO',
+      dueDate: null, startDate: null, scheduledDate: null, completedDate: null,
+      priority: 'none', tags: [], recurrenceRule: '', body: '',
+    };
+
+    it('appends the global filter tag in emoji output', () => {
+      const md = mapper.toMarkdown(baseTask, 'sync', 'emoji', 'task');
+      expect(md).toBe('- [ ] Test task 🆔 test-id #task #sync');
+    });
+
+    it('appends the global filter tag in dataview output', () => {
+      const md = mapper.toMarkdown(baseTask, 'sync', 'dataview', 'task');
+      expect(md).toBe('- [ ] Test task [id:: test-id] #task #sync');
+    });
+
+    it('accepts a global filter that already has a # prefix', () => {
+      const md = mapper.toMarkdown(baseTask, 'sync', 'emoji', '#task');
+      expect(md).toBe('- [ ] Test task 🆔 test-id #task #sync');
+    });
+
+    it('omits the global filter when empty', () => {
+      const md = mapper.toMarkdown(baseTask, 'sync', 'emoji', '');
+      expect(md).toBe('- [ ] Test task 🆔 test-id #sync');
+    });
+
+    it('appends the global filter when there is no sync tag', () => {
+      const md = mapper.toMarkdown(baseTask, '', 'emoji', 'task');
+      expect(md).toBe('- [ ] Test task 🆔 test-id #task');
+    });
+
+    it('does not duplicate the global filter when it equals the sync tag', () => {
+      const md = mapper.toMarkdown(baseTask, 'task', 'emoji', '#task');
+      expect((md.match(/#task/g) || []).length).toBe(1);
+    });
+
+    it('does not duplicate the global filter when present in task tags', () => {
+      const task = { ...baseTask, tags: ['task', 'shopping'] };
+      const md = mapper.toMarkdown(task, 'sync', 'emoji', '#task');
+      expect((md.match(/#task/g) || []).length).toBe(1);
+      expect(md).toContain('#shopping');
+    });
+
+    it('dedupes case-insensitively when task tags differ in case', () => {
+      const task = { ...baseTask, tags: ['Task', 'shopping'] };
+      const md = mapper.toMarkdown(task, 'sync', 'emoji', '#task');
+      expect((md.match(/#[Tt]ask/g) || []).length).toBe(1);
+      expect(md).toContain('#shopping');
+    });
+
+    it('dedupes case-insensitively when global filter equals sync tag', () => {
+      const md = mapper.toMarkdown(baseTask, 'Task', 'emoji', '#task');
+      expect((md.match(/#[Tt]ask/g) || []).length).toBe(1);
+    });
+  });
+
 });

--- a/src/tasks/obsidianMapper.ts
+++ b/src/tasks/obsidianMapper.ts
@@ -14,6 +14,12 @@ export class ObsidianMapper {
   /**
    * Parse: ObsidianTask → CommonTask.
    */
+  /**
+   * Note: the obsidian-tasks global filter is intentionally not re-added here.
+   * obsidian-tasks strips it from `task.tags` (and `cleanDescription` drops
+   * any stray text form). `toMarkdown` re-emits it on writeback so the
+   * rewritten line stays recognised under the filter — issue #93.
+   */
   toCommonTask(task: ObsidianTask, taskId: string, body: string = ''): CommonTask {
     return {
       uid: taskId,
@@ -35,20 +41,25 @@ export class ObsidianMapper {
    * Uses task.uid for the id field. `format` defaults to 'emoji' so
    * existing callers are unaffected.
    */
-  toMarkdown(task: CommonTask, syncTag?: string, format: 'emoji' | 'dataview' = 'emoji'): string {
+  toMarkdown(
+    task: CommonTask,
+    syncTag?: string,
+    format: 'emoji' | 'dataview' = 'emoji',
+    globalFilter?: string,
+  ): string {
     return format === 'dataview'
-      ? this.toDataviewMarkdown(task, syncTag)
-      : this.toEmojiMarkdown(task, syncTag);
+      ? this.toDataviewMarkdown(task, syncTag, globalFilter)
+      : this.toEmojiMarkdown(task, syncTag, globalFilter);
   }
 
-  private toEmojiMarkdown(task: CommonTask, syncTag?: string): string {
+  private toEmojiMarkdown(task: CommonTask, syncTag?: string, globalFilter?: string): string {
     let line = task.status === 'DONE' ? '- [x] ' : '- [ ] ';
 
     line += task.title;
 
-    const syncTagName = syncTag?.replace(/^#/, '').trim();
-    const nonSyncTags = task.tags.filter(t => t !== syncTagName);
-    for (const tag of nonSyncTags) {
+    const syncTagName = this.bareTagName(syncTag);
+    const globalFilterName = this.bareTagName(globalFilter);
+    for (const tag of this.nonReservedTags(task.tags, syncTagName, globalFilterName)) {
       line += ` #${tag}`;
     }
 
@@ -74,22 +85,19 @@ export class ObsidianMapper {
 
     line += ` 🆔 ${task.uid}`;
 
-    if (syncTag && syncTag.trim() !== '') {
-      const tag = syncTag.startsWith('#') ? syncTag : `#${syncTag}`;
-      line += ` ${tag}`;
-    }
+    line += this.trailingTagSuffix(syncTagName, globalFilterName);
 
     return this.appendBody(line, task.body);
   }
 
-  private toDataviewMarkdown(task: CommonTask, syncTag?: string): string {
+  private toDataviewMarkdown(task: CommonTask, syncTag?: string, globalFilter?: string): string {
     let line = task.status === 'DONE' ? '- [x] ' : '- [ ] ';
 
     line += task.title;
 
-    const syncTagName = syncTag?.replace(/^#/, '').trim();
-    const nonSyncTags = task.tags.filter(t => t !== syncTagName);
-    for (const tag of nonSyncTags) {
+    const syncTagName = this.bareTagName(syncTag);
+    const globalFilterName = this.bareTagName(globalFilter);
+    for (const tag of this.nonReservedTags(task.tags, syncTagName, globalFilterName)) {
       line += ` #${tag}`;
     }
 
@@ -116,12 +124,42 @@ export class ObsidianMapper {
 
     line += ` [id:: ${task.uid}]`;
 
-    if (syncTag && syncTag.trim() !== '') {
-      const tag = syncTag.startsWith('#') ? syncTag : `#${syncTag}`;
-      line += ` ${tag}`;
-    }
+    line += this.trailingTagSuffix(syncTagName, globalFilterName);
 
     return this.appendBody(line, task.body);
+  }
+
+  private bareTagName(tag: string | undefined): string {
+    return tag?.replace(/^#/, '').trim() ?? '';
+  }
+
+  /**
+   * Drop tags that we re-emit explicitly (sync tag + global filter) so the
+   * suffix renders them exactly once. Comparisons are case-insensitive — both
+   * obsidian-tasks and Obsidian itself treat tags case-insensitively.
+   */
+  private nonReservedTags(tags: string[], syncTagName: string, globalFilterName: string): string[] {
+    const reserved = new Set(
+      [syncTagName, globalFilterName].filter(Boolean).map(t => t.toLowerCase()),
+    );
+    return tags.filter(t => !reserved.has(t.toLowerCase()));
+  }
+
+  /**
+   * Trailing global filter + sync tag suffix. Global filter goes first so
+   * obsidian-tasks recognises the line; sync tag last (existing convention).
+   * Skips the global filter if it equals the sync tag (case-insensitive) to
+   * avoid duplication.
+   */
+  private trailingTagSuffix(syncTagName: string, globalFilterName: string): string {
+    let out = '';
+    if (globalFilterName && globalFilterName.toLowerCase() !== syncTagName.toLowerCase()) {
+      out += ` #${globalFilterName}`;
+    }
+    if (syncTagName) {
+      out += ` #${syncTagName}`;
+    }
+    return out;
   }
 
   /** Append the task body as indented bullet lines, if any. */

--- a/src/tasks/obsidianTasksWrapper.test.ts
+++ b/src/tasks/obsidianTasksWrapper.test.ts
@@ -906,82 +906,49 @@ More content`;
         });
     });
 
-    describe('getConfiguredFormat', () => {
+    describe('getTasksPluginConfig', () => {
         function wrapperWith(tasksPlugin: unknown): ObsidianTasksWrapper {
             const app = { vault: {}, plugins: { plugins: tasksPlugin ? { 'obsidian-tasks-plugin': tasksPlugin } : {} } };
             return new ObsidianTasksWrapper(app as unknown as App);
         }
 
-        it("returns 'dataview' when obsidian-tasks is configured for dataview", async () => {
-            const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({ taskFormat: 'dataview' }) });
-            await expect(w.getConfiguredFormat()).resolves.toBe('dataview');
+        const defaults = { format: 'emoji', globalFilter: '' };
+
+        it('reads format and globalFilter from a single loadData call', async () => {
+            const loadData = jest.fn().mockResolvedValue({ taskFormat: 'dataview', globalFilter: '#task' });
+            const w = wrapperWith({ loadData });
+            await expect(w.getTasksPluginConfig()).resolves.toEqual({ format: 'dataview', globalFilter: '#task' });
+            expect(loadData).toHaveBeenCalledTimes(1);
         });
 
-        it("returns 'emoji' when obsidian-tasks is configured for tasksPluginEmoji", async () => {
+        it("maps unrecognised taskFormat values to 'emoji'", async () => {
             const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({ taskFormat: 'tasksPluginEmoji' }) });
-            await expect(w.getConfiguredFormat()).resolves.toBe('emoji');
+            await expect(w.getTasksPluginConfig()).resolves.toEqual(defaults);
         });
 
-        it("returns 'emoji' when taskFormat key is missing", async () => {
-            const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({}) });
-            await expect(w.getConfiguredFormat()).resolves.toBe('emoji');
-        });
-
-        it("returns 'emoji' when loadData returns null", async () => {
-            const w = wrapperWith({ loadData: jest.fn().mockResolvedValue(null) });
-            await expect(w.getConfiguredFormat()).resolves.toBe('emoji');
-        });
-
-        it("returns 'emoji' when the obsidian-tasks plugin is absent", async () => {
-            const w = wrapperWith(null);
-            await expect(w.getConfiguredFormat()).resolves.toBe('emoji');
-        });
-
-        it("returns 'emoji' when loadData throws", async () => {
-            const w = wrapperWith({ loadData: jest.fn().mockRejectedValue(new Error('boom')) });
-            await expect(w.getConfiguredFormat()).resolves.toBe('emoji');
-        });
-    });
-
-    describe('getGlobalFilter', () => {
-        function wrapperWith(tasksPlugin: unknown): ObsidianTasksWrapper {
-            const app = { vault: {}, plugins: { plugins: tasksPlugin ? { 'obsidian-tasks-plugin': tasksPlugin } : {} } };
-            return new ObsidianTasksWrapper(app as unknown as App);
-        }
-
-        it('returns the configured global filter', async () => {
-            const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({ globalFilter: '#task' }) });
-            await expect(w.getGlobalFilter()).resolves.toBe('#task');
-        });
-
-        it('returns the configured global filter without # prefix', async () => {
+        it('preserves a globalFilter without # prefix', async () => {
             const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({ globalFilter: 'todo' }) });
-            await expect(w.getGlobalFilter()).resolves.toBe('todo');
+            await expect(w.getTasksPluginConfig()).resolves.toEqual({ format: 'emoji', globalFilter: 'todo' });
         });
 
-        it("returns '' when globalFilter is missing", async () => {
+        it('returns defaults when both keys are missing', async () => {
             const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({}) });
-            await expect(w.getGlobalFilter()).resolves.toBe('');
+            await expect(w.getTasksPluginConfig()).resolves.toEqual(defaults);
         });
 
-        it("returns '' when globalFilter is empty string", async () => {
-            const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({ globalFilter: '' }) });
-            await expect(w.getGlobalFilter()).resolves.toBe('');
-        });
-
-        it("returns '' when loadData returns null", async () => {
+        it('returns defaults when loadData returns null', async () => {
             const w = wrapperWith({ loadData: jest.fn().mockResolvedValue(null) });
-            await expect(w.getGlobalFilter()).resolves.toBe('');
+            await expect(w.getTasksPluginConfig()).resolves.toEqual(defaults);
         });
 
-        it("returns '' when the obsidian-tasks plugin is absent", async () => {
+        it('returns defaults when the obsidian-tasks plugin is absent', async () => {
             const w = wrapperWith(null);
-            await expect(w.getGlobalFilter()).resolves.toBe('');
+            await expect(w.getTasksPluginConfig()).resolves.toEqual(defaults);
         });
 
-        it("returns '' when loadData throws", async () => {
+        it('returns defaults when loadData throws', async () => {
             const w = wrapperWith({ loadData: jest.fn().mockRejectedValue(new Error('boom')) });
-            await expect(w.getGlobalFilter()).resolves.toBe('');
+            await expect(w.getTasksPluginConfig()).resolves.toEqual(defaults);
         });
     });
 

--- a/src/tasks/obsidianTasksWrapper.test.ts
+++ b/src/tasks/obsidianTasksWrapper.test.ts
@@ -943,6 +943,48 @@ More content`;
         });
     });
 
+    describe('getGlobalFilter', () => {
+        function wrapperWith(tasksPlugin: unknown): ObsidianTasksWrapper {
+            const app = { vault: {}, plugins: { plugins: tasksPlugin ? { 'obsidian-tasks-plugin': tasksPlugin } : {} } };
+            return new ObsidianTasksWrapper(app as unknown as App);
+        }
+
+        it('returns the configured global filter', async () => {
+            const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({ globalFilter: '#task' }) });
+            await expect(w.getGlobalFilter()).resolves.toBe('#task');
+        });
+
+        it('returns the configured global filter without # prefix', async () => {
+            const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({ globalFilter: 'todo' }) });
+            await expect(w.getGlobalFilter()).resolves.toBe('todo');
+        });
+
+        it("returns '' when globalFilter is missing", async () => {
+            const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({}) });
+            await expect(w.getGlobalFilter()).resolves.toBe('');
+        });
+
+        it("returns '' when globalFilter is empty string", async () => {
+            const w = wrapperWith({ loadData: jest.fn().mockResolvedValue({ globalFilter: '' }) });
+            await expect(w.getGlobalFilter()).resolves.toBe('');
+        });
+
+        it("returns '' when loadData returns null", async () => {
+            const w = wrapperWith({ loadData: jest.fn().mockResolvedValue(null) });
+            await expect(w.getGlobalFilter()).resolves.toBe('');
+        });
+
+        it("returns '' when the obsidian-tasks plugin is absent", async () => {
+            const w = wrapperWith(null);
+            await expect(w.getGlobalFilter()).resolves.toBe('');
+        });
+
+        it("returns '' when loadData throws", async () => {
+            const w = wrapperWith({ loadData: jest.fn().mockRejectedValue(new Error('boom')) });
+            await expect(w.getGlobalFilter()).resolves.toBe('');
+        });
+    });
+
 });
 
 

--- a/src/tasks/obsidianTasksWrapper.ts
+++ b/src/tasks/obsidianTasksWrapper.ts
@@ -470,4 +470,27 @@ export class ObsidianTasksWrapper {
         }
     }
 
+    /**
+     * The obsidian-tasks "global filter" tag. When set, obsidian-tasks only
+     * parses lines containing this tag and strips it from `task.tags`, so we
+     * must re-add it when writing tasks back to keep them recognised.
+     * Returns '' when unset, absent, or unreadable.
+     */
+    async getGlobalFilter(): Promise<string> {
+        const appWithPlugins = this.app as App & {
+            plugins: { plugins: Record<string, { loadData?: () => Promise<unknown> }> };
+        };
+        const tasksPlugin = appWithPlugins.plugins.plugins['obsidian-tasks-plugin'];
+        if (!tasksPlugin || typeof tasksPlugin.loadData !== 'function') {
+            return '';
+        }
+        try {
+            const data = await tasksPlugin.loadData();
+            const filter = (data as { globalFilter?: unknown } | null)?.globalFilter;
+            return typeof filter === 'string' ? filter : '';
+        } catch {
+            return '';
+        }
+    }
+
 }

--- a/src/tasks/obsidianTasksWrapper.ts
+++ b/src/tasks/obsidianTasksWrapper.ts
@@ -447,49 +447,34 @@ export class ObsidianTasksWrapper {
     }
 
     /**
-     * The task format obsidian-tasks itself is configured to write.
-     * Read from its persisted settings (its in-memory settings live in a
-     * module closure and are not reliably exposed). Anything other than
-     * 'dataview' — including a missing plugin or a read error — maps to
-     * 'emoji', which is obsidian-tasks' own default.
+     * Read the obsidian-tasks persisted settings we depend on:
+     *   - `format`: which markdown format to write (its in-memory settings
+     *     live in a module closure and are not reliably exposed, so we read
+     *     `loadData()`). Anything other than 'dataview' maps to 'emoji'.
+     *   - `globalFilter`: when set, obsidian-tasks only parses lines
+     *     containing this tag and strips it from `task.tags`, so we re-add
+     *     it on writeback to keep them recognised. '' when unset.
+     *
+     * Missing plugin, missing method, or any read error returns the safe
+     * defaults (`{ format: 'emoji', globalFilter: '' }`).
      */
-    async getConfiguredFormat(): Promise<'emoji' | 'dataview'> {
+    async getTasksPluginConfig(): Promise<{ format: 'emoji' | 'dataview'; globalFilter: string }> {
+        const defaults = { format: 'emoji' as const, globalFilter: '' };
         const appWithPlugins = this.app as App & {
             plugins: { plugins: Record<string, { loadData?: () => Promise<unknown> }> };
         };
         const tasksPlugin = appWithPlugins.plugins.plugins['obsidian-tasks-plugin'];
         if (!tasksPlugin || typeof tasksPlugin.loadData !== 'function') {
-            return 'emoji';
+            return defaults;
         }
         try {
-            const data = await tasksPlugin.loadData();
-            const fmt = (data as { taskFormat?: unknown } | null)?.taskFormat;
-            return fmt === 'dataview' ? 'dataview' : 'emoji';
+            const data = (await tasksPlugin.loadData()) as { taskFormat?: unknown; globalFilter?: unknown } | null;
+            return {
+                format: data?.taskFormat === 'dataview' ? 'dataview' : 'emoji',
+                globalFilter: typeof data?.globalFilter === 'string' ? data.globalFilter : '',
+            };
         } catch {
-            return 'emoji';
-        }
-    }
-
-    /**
-     * The obsidian-tasks "global filter" tag. When set, obsidian-tasks only
-     * parses lines containing this tag and strips it from `task.tags`, so we
-     * must re-add it when writing tasks back to keep them recognised.
-     * Returns '' when unset, absent, or unreadable.
-     */
-    async getGlobalFilter(): Promise<string> {
-        const appWithPlugins = this.app as App & {
-            plugins: { plugins: Record<string, { loadData?: () => Promise<unknown> }> };
-        };
-        const tasksPlugin = appWithPlugins.plugins.plugins['obsidian-tasks-plugin'];
-        if (!tasksPlugin || typeof tasksPlugin.loadData !== 'function') {
-            return '';
-        }
-        try {
-            const data = await tasksPlugin.loadData();
-            const filter = (data as { globalFilter?: unknown } | null)?.globalFilter;
-            return typeof filter === 'string' ? filter : '';
-        } catch {
-            return '';
+            return defaults;
         }
     }
 

--- a/test/wdio/specs/globalFilter.e2e.ts
+++ b/test/wdio/specs/globalFilter.e2e.ts
@@ -1,0 +1,71 @@
+import { browser } from '@wdio/globals';
+import { createIsolatedCalendar } from '../../helpers/radicaleSetup';
+import { useCalendar, waitForTaskInCache, syncNow } from '../helpers/pluginConfig';
+import { appendTaskLine } from '../helpers/vaultEdit';
+
+/**
+ * Issue #93: when obsidian-tasks has a `globalFilter` configured, it strips
+ * the filter tag from `task.tags` during parsing. Our plugin must re-add it
+ * when writing tasks back, otherwise obsidian-tasks stops recognising the
+ * rewritten line as a task.
+ */
+
+async function setObsidianTasksGlobalFilter(filter: string): Promise<void> {
+  await browser.executeObsidian(async ({ app }, args) => {
+    const tp = (app as any).plugins.plugins['obsidian-tasks-plugin'];
+    const data = ((await tp.loadData()) as Record<string, unknown> | null) ?? {};
+    data.globalFilter = args.filter;
+    await tp.saveData(data);
+  }, { filter });
+  // Reload Obsidian so obsidian-tasks loads the new setting cleanly.
+  await browser.reloadObsidian({ plugins: ['tasks-caldav-sync', 'obsidian-tasks-plugin'] });
+}
+
+async function readVaultFile(filePath: string): Promise<string> {
+  return browser.executeObsidian(async ({ app }, args) => {
+    const f = app.vault.getAbstractFileByPath(args.filePath);
+    return f ? app.vault.read(f as any) : '';
+  }, { filePath });
+}
+
+describe('obsidian-tasks global filter', function () {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeEach(async function () {
+    const cal = await createIsolatedCalendar();
+    cleanup = cal.cleanup;
+    await setObsidianTasksGlobalFilter('#task');
+    await useCalendar(cal.calendarName);
+  });
+
+  afterEach(async function () {
+    await setObsidianTasksGlobalFilter('');
+    await cleanup?.();
+  });
+
+  it('preserves the global filter tag when writing a task back to the vault', async function () {
+    const title = `GlobalFilter ${Date.now()}`;
+    await appendTaskLine('Tasks.md', `- [ ] ${title} #task #sync`);
+
+    await waitForTaskInCache(title);
+    await syncNow();
+
+    // After sync, the plugin writes back an ID. The line must still carry
+    // #task so obsidian-tasks keeps recognising it under the global filter.
+    await browser.waitUntil(async () => {
+      const content = await readVaultFile('Tasks.md');
+      const line = content.split('\n').find(l => l.includes(title));
+      if (!line) return false;
+      const hasId = line.includes('🆔') || line.includes('[id::');
+      return hasId && /#task(\s|$)/.test(line);
+    }, { timeout: 15000, interval: 500, timeoutMsg: 'task line missing #task or id after sync' });
+
+    // And obsidian-tasks still parses the rewritten line as a task.
+    await browser.waitUntil(async () => {
+      return browser.executeObsidian(({ app }, t) => {
+        const tp = (app as any).plugins.plugins['obsidian-tasks-plugin'];
+        return tp.getTasks().some((task: any) => task.description.includes(t));
+      }, title);
+    }, { timeout: 15000, interval: 500, timeoutMsg: 'task no longer recognised by obsidian-tasks after sync' });
+  });
+});


### PR DESCRIPTION
Fixes #93.

## Summary
- When obsidian-tasks has a `globalFilter` (e.g. `#task`), it strips that tag from `task.tags` while parsing. Our plugin rewrote tasks back to the vault without it, so obsidian-tasks stopped recognising the rewritten line — `not done` queries lost the task.
- Auto-detect `globalFilter` from obsidian-tasks' persisted settings (`loadData()`) and re-emit it on writeback in both emoji and dataview formats. Dedup is case-insensitive against the sync tag and against existing `task.tags`.
- Fetch path needs no change: obsidian-tasks already strips the tag and `cleanDescription` drops any stray text form. A short comment in `toCommonTask` documents this asymmetry so it isn't "normalised away" later.

## Notes
- Code review surfaced a case-sensitivity bug in an earlier draft (`globalFilter: '#Task'` + tag `task` would have double-emitted). Both the dedup and the equals-sync-tag short-circuit are now case-insensitive. Tests cover this.

## Test plan
- [x] Jest unit + E2E: 453 passing
- [x] WDIO: 8/8 passing — new `globalFilter.e2e.ts` reloads Obsidian with `globalFilter: '#task'`, creates `- [ ] foo #task #sync`, syncs, asserts the rewritten line still contains `#task` (with word boundary) AND obsidian-tasks' cache still parses it
- [x] Bug reproducer confirmed: disabling the new suffix branch makes the wdio spec fail with `- [ ] foo 🆔 ID #sync` (no `#task`)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)