### PR TITLE
chore(deps): force serialize-javascript >=7.0.5 to fix dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tasks-caldav-sync",
-	"version": "1.1.7",
+	"version": "1.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tasks-caldav-sync",
-			"version": "1.1.7",
+			"version": "1.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"rrule": "^2.8.1"
@@ -11436,16 +11436,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/react-is": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -12120,13 +12110,13 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
 	},
 	"dependencies": {
 		"rrule": "^2.8.1"
+	},
+	"overrides": {
+		"serialize-javascript": "^7.0.5"
 	}
 }


### PR DESCRIPTION
## Summary
- Adds an npm `overrides` entry pinning `serialize-javascript` to `^7.0.5`
- Resolves the two open Dependabot alerts pulled in transitively via `@wdio/mocha-framework → mocha`:
  - GHSA-5c6j-r48x-rmvq (high — RCE via `RegExp.flags` / `Date.prototype.toISOString`)
  - GHSA-qj8w-gfj5-8c6v (moderate — CPU exhaustion DoS)

Dependabot has not auto-opened a PR for these, so applying manually.

## Test plan
- [x] `npm install` succeeds; lockfile updates `serialize-javascript` to 7.0.5
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run test:unit` — 410/410 passing
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)