### PR TITLE
fix(diff): treat convergent edits as resolved, not conflicts

### DIFF
--- a/src/sync/diff.test.ts
+++ b/src/sync/diff.test.ts
@@ -248,6 +248,55 @@ describe('diff', () => {
     });
   });
 
+  describe('convergent edits', () => {
+    it('should not conflict when both sides edit title to the same value', () => {
+      const baseline = makeCommonTask({ uid: 't1', title: 'Original' });
+      const obsidian = makeCommonTask({ uid: 't1', title: 'Buy bread' });
+      const caldav = makeCommonTask({ uid: 't1', title: 'Buy bread' });
+
+      const result = diff([obsidian], [caldav], [baseline], 'caldav-wins');
+
+      expect(result.toObsidian).toHaveLength(0);
+      expect(result.toCalDAV).toHaveLength(0);
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it('should not conflict when both sides add the same tag', () => {
+      const baseline = makeCommonTask({ uid: 't1', tags: [] });
+      const obsidian = makeCommonTask({ uid: 't1', tags: ['urgent'] });
+      const caldav = makeCommonTask({ uid: 't1', tags: ['urgent'] });
+
+      const result = diff([obsidian], [caldav], [baseline], 'caldav-wins');
+
+      expect(result.toObsidian).toHaveLength(0);
+      expect(result.toCalDAV).toHaveLength(0);
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it('should not conflict when both sides mark the task DONE', () => {
+      const baseline = makeCommonTask({ uid: 't1', status: 'TODO' });
+      const obsidian = makeCommonTask({ uid: 't1', status: 'DONE', completedDate: '2025-01-15' });
+      const caldav = makeCommonTask({ uid: 't1', status: 'DONE', completedDate: '2025-01-15' });
+
+      const result = diff([obsidian], [caldav], [baseline], 'caldav-wins');
+
+      expect(result.toObsidian).toHaveLength(0);
+      expect(result.toCalDAV).toHaveLength(0);
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it('should still conflict when both sides edit but to different values', () => {
+      const baseline = makeCommonTask({ uid: 't1', title: 'Original' });
+      const obsidian = makeCommonTask({ uid: 't1', title: 'Obsidian version' });
+      const caldav = makeCommonTask({ uid: 't1', title: 'CalDAV version' });
+
+      const result = diff([obsidian], [caldav], [baseline], 'caldav-wins');
+
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0].uid).toBe('t1');
+    });
+  });
+
   describe('first sync (both sides present, no baseline)', () => {
     it('should use caldav-wins strategy when no baseline exists', () => {
       const obsidian = makeCommonTask({ uid: 't1', title: 'Obsidian' });

--- a/src/sync/diff.ts
+++ b/src/sync/diff.ts
@@ -80,6 +80,11 @@ export function diff(
       const calChanged = !tasksEqual(cal, base);
 
       if (obsChanged && calChanged) {
+        if (tasksEqual(obs, cal)) {
+          // Convergent edit: both sides arrived at the same value, nothing to do.
+          // Baseline catches up on the next successful sync.
+          continue;
+        }
         // Conflict: both sides modified
         if (strategy === 'obsidian-wins') {
           toCalDAV.push({ type: resolveChangeType(obs, base), task: obs, previousVersion: base });


### PR DESCRIPTION
## Summary

- The three-way diff in `src/sync/diff.ts` treated "both sides edited" as a conflict unconditionally.
- When the user happens to make the same edit on both sides (e.g. retitling a task identically on iOS and in Obsidian before the next sync), there is nothing to resolve, but the previous logic still recorded a conflict and forced one side to overwrite the other.
- Fix: inside the `obsChanged && calChanged` branch, if `tasksEqual(obs, cal)` we skip the entry entirely (no `toObsidian`, no `toCalDAV`, no `conflicts`). The baseline naturally catches up on the next successful sync.

## Test plan

- [x] Unit test: convergent title edit on both sides produces no writes and no conflicts.
- [x] Unit test: convergent tag addition on both sides produces no writes and no conflicts.
- [x] Unit test: convergent completion (both sides mark DONE) produces no writes and no conflicts.
- [x] Regression: genuinely divergent edits still produce a conflict.
- [x] `npm run build` passes.
- [x] `npm run lint` passes.
- [x] `npm test` passes (451 tests).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>