### PR TITLE
feat(migrations): gate each migration to run at most once

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -16,7 +16,9 @@ export default class CalDAVSyncPlugin extends Plugin {
 	async onload() {
 		await this.loadSettings();
 
-		await runMigrations(this.app, this.settings);
+		if (await runMigrations(this.app, this.settings)) {
+			await this.saveData(this.settings);
+		}
 
 		await this.initializeEngines();
 

--- a/src/migrations/migrationRunner.test.ts
+++ b/src/migrations/migrationRunner.test.ts
@@ -1,5 +1,5 @@
 import { App } from 'obsidian';
-import { runMigrations, Migration } from './migrationRunner';
+import { runMigrations, Migration, __setMigrationsForTesting, __resetMigrationsForTesting } from './migrationRunner';
 import { mappingJsonToIdMapping } from './001-mapping-json-to-id-mapping';
 import { flatStorageToPerCalendar } from './002-flat-storage-to-per-calendar';
 import { CalDAVSettings, DEFAULT_CALDAV_SETTINGS } from '../types';
@@ -55,7 +55,117 @@ describe('runMigrations', () => {
     adapter.exists.mockResolvedValue(false);
     const app = createMockApp(adapter);
 
-    await expect(runMigrations(app, DEFAULT_CALDAV_SETTINGS)).resolves.toBeUndefined();
+    await expect(runMigrations(app, { ...DEFAULT_CALDAV_SETTINGS })).resolves.toBe(true);
+  });
+});
+
+describe('runMigrations gating via appliedMigrations', () => {
+  afterEach(() => {
+    __resetMigrationsForTesting();
+  });
+
+  function makeMigration(name: string, calls: string[], opts: { throws?: boolean } = {}): Migration {
+    return {
+      name,
+      async run() {
+        await Promise.resolve();
+        if (opts.throws) {
+          throw new Error(`boom-${name}`);
+        }
+        calls.push(name);
+      },
+    };
+  }
+
+  function emptyApp(): App {
+    const adapter = createMockAdapter();
+    adapter.exists.mockResolvedValue(false);
+    return createMockApp(adapter);
+  }
+
+  it('runs every migration and records each name when appliedMigrations is empty', async () => {
+    const calls: string[] = [];
+    __setMigrationsForTesting([
+      makeMigration('m-a', calls),
+      makeMigration('m-b', calls),
+    ]);
+
+    const settings: CalDAVSettings = { ...DEFAULT_CALDAV_SETTINGS };
+
+    const dirty = await runMigrations(emptyApp(), settings);
+
+    expect(calls).toEqual(['m-a', 'm-b']);
+    expect(settings.appliedMigrations).toEqual(['m-a', 'm-b']);
+    expect(dirty).toBe(true);
+  });
+
+  it('treats absent appliedMigrations the same as an empty array', async () => {
+    const calls: string[] = [];
+    __setMigrationsForTesting([makeMigration('m-a', calls)]);
+
+    const settings: CalDAVSettings = { ...DEFAULT_CALDAV_SETTINGS };
+    expect(settings.appliedMigrations).toBeUndefined();
+
+    await runMigrations(emptyApp(), settings);
+
+    expect(calls).toEqual(['m-a']);
+    expect(settings.appliedMigrations).toEqual(['m-a']);
+  });
+
+  it('only runs migrations not already in appliedMigrations', async () => {
+    const calls: string[] = [];
+    __setMigrationsForTesting([
+      makeMigration('m-a', calls),
+      makeMigration('m-b', calls),
+      makeMigration('m-c', calls),
+    ]);
+
+    const settings: CalDAVSettings = {
+      ...DEFAULT_CALDAV_SETTINGS,
+      appliedMigrations: ['m-a', 'm-c'],
+    };
+
+    const dirty = await runMigrations(emptyApp(), settings);
+
+    expect(calls).toEqual(['m-b']);
+    expect(settings.appliedMigrations).toEqual(expect.arrayContaining(['m-a', 'm-b', 'm-c']));
+    expect(settings.appliedMigrations).toHaveLength(3);
+    expect(dirty).toBe(true);
+  });
+
+  it('skips every migration and returns false when appliedMigrations covers them all', async () => {
+    const calls: string[] = [];
+    __setMigrationsForTesting([
+      makeMigration('m-a', calls),
+      makeMigration('m-b', calls),
+    ]);
+
+    const settings: CalDAVSettings = {
+      ...DEFAULT_CALDAV_SETTINGS,
+      appliedMigrations: ['m-a', 'm-b'],
+    };
+
+    const dirty = await runMigrations(emptyApp(), settings);
+
+    expect(calls).toEqual([]);
+    expect(settings.appliedMigrations).toEqual(['m-a', 'm-b']);
+    expect(dirty).toBe(false);
+  });
+
+  it('does not record a failing migration and aborts the chain', async () => {
+    const calls: string[] = [];
+    __setMigrationsForTesting([
+      makeMigration('m-a', calls),
+      makeMigration('m-b', calls, { throws: true }),
+      makeMigration('m-c', calls),
+    ]);
+
+    const settings: CalDAVSettings = { ...DEFAULT_CALDAV_SETTINGS };
+
+    await expect(runMigrations(emptyApp(), settings)).rejects.toThrow('boom-m-b');
+
+    expect(calls).toEqual(['m-a']);
+    expect(settings.appliedMigrations).toEqual(['m-a']);
   });
 });
 

--- a/src/migrations/migrationRunner.ts
+++ b/src/migrations/migrationRunner.ts
@@ -8,13 +8,47 @@ export interface Migration {
   run(app: App, settings: CalDAVSettings): Promise<void>;
 }
 
-const migrations: Migration[] = [
+const registeredMigrations: Migration[] = [
   mappingJsonToIdMapping,
   flatStorageToPerCalendar,
 ];
 
-export async function runMigrations(app: App, settings: CalDAVSettings): Promise<void> {
-  for (const migration of migrations) {
-    await migration.run(app, settings);
+let activeMigrations: Migration[] = registeredMigrations;
+
+/**
+ * Runs every registered migration whose name is not already recorded in
+ * `settings.appliedMigrations`. On success the migration's name is appended to
+ * the set. A failing migration aborts the chain and is NOT recorded, so it
+ * retries on the next plugin load. Returns `true` iff at least one migration
+ * was applied during this call, allowing the caller to skip a redundant
+ * settings write when nothing changed.
+ */
+export async function runMigrations(app: App, settings: CalDAVSettings): Promise<boolean> {
+  const applied = new Set(settings.appliedMigrations ?? []);
+  let ran = false;
+
+  try {
+    for (const migration of activeMigrations) {
+      if (applied.has(migration.name)) continue;
+      await migration.run(app, settings);
+      applied.add(migration.name);
+      ran = true;
+    }
+  } finally {
+    if (ran) {
+      settings.appliedMigrations = Array.from(applied);
+    }
   }
+
+  return ran;
+}
+
+/** Test-only: replace the registered migration list. */
+export function __setMigrationsForTesting(migrations: Migration[]): void {
+  activeMigrations = migrations;
+}
+
+/** Test-only: restore the production migration list. */
+export function __resetMigrationsForTesting(): void {
+  activeMigrations = registeredMigrations;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,12 @@ export interface CalDAVSettings {
   deleteBehavior: 'ask' | 'deleteCalDAV' | 'deleteObsidian' | 'keepBoth';
   includeObsidianLink: boolean;
   showAutoSyncNotifications: boolean;
+  /**
+   * Names of migrations that have already been applied to this vault. Used by
+   * {@link runMigrations} to gate each migration to a single successful run,
+   * independent of the migration's own pre-state idempotency checks.
+   */
+  appliedMigrations?: string[];
 }
 
 export const DEFAULT_CALDAV_SETTINGS: CalDAVSettings = {


### PR DESCRIPTION
## Summary

`runMigrations` previously executed every registered migration on every plugin load and relied on each migration's own pre-state check (e.g. "skip if the produced file already exists") for idempotency. That is fragile — a single buggy pre-state check silently re-runs its mutation on every load.

This PR adds explicit gating:

- New optional `appliedMigrations?: string[]` in `CalDAVSettings`.
- `runMigrations` builds a set from that field, skips any migration whose name is already in it, and records the name after a successful run.
- A migration that throws is **not** recorded and **aborts the chain** — so it retries next load and later migrations never see an inconsistent intermediate state.
- `runMigrations` now returns a dirty bit; `main.ts` only calls `saveData` when at least one migration ran.

**Backward compat:** existing installs have no `appliedMigrations` field. On first load post-upgrade the set is empty, so every registered migration (001, 002) runs once. Both are already idempotent via their own pre-state checks, so re-running on an already-migrated install is a safe no-op. The field is populated afterwards and they never run again.

Single-purpose change — touches only `src/types.ts`, `src/migrations/migrationRunner.ts`, `main.ts`, and the existing test file.

## Test plan

- [x] `npm run build` (tsc + esbuild) passes
- [x] `npm run lint` passes
- [x] `npm test` — 452 tests pass
- [x] New unit tests cover: empty set runs all and records them; partial set runs only the un-listed ones; full set runs nothing and returns false; throwing migration is not recorded and aborts the chain
- [ ] Manual smoke: load plugin on a fresh vault, confirm `appliedMigrations` appears in `data.json` after first run, and a second load performs no migration writes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)