### PR TITLE
fix(tasks): strip nested tags from task title (#114)

### DIFF
--- a/src/tasks/obsidianMapper.test.ts
+++ b/src/tasks/obsidianMapper.test.ts
@@ -66,6 +66,19 @@ describe('ObsidianMapper', () => {
       expect(mapper.toCommonTask(task, 'test-001').title).toBe('Buy groceries');
     });
 
+    // Issue #114: nested tags (#work/sample_project) were only partially
+    // stripped from the description, leaving `/sample_project` garbage in the
+    // title that compounded into duplicate tags on every sync.
+    it('should clean nested tags from description', () => {
+      const task = makeTask({
+        description: '#wtd #work/sample_project #work/java Do something',
+        tags: ['#wtd', '#work/sample_project', '#work/java'],
+      });
+      const common = mapper.toCommonTask(task, 'id');
+      expect(common.title).toBe('Do something');
+      expect(common.tags).toEqual(['wtd', 'work/sample_project', 'work/java']);
+    });
+
     it('should clean # prefix from tags', () => {
       const task = makeTask({ tags: ['#sync', '#work', 'plain'] });
       expect(mapper.toCommonTask(task, 'id').tags).toEqual(['sync', 'work', 'plain']);

--- a/src/tasks/obsidianMapper.ts
+++ b/src/tasks/obsidianMapper.ts
@@ -177,8 +177,9 @@ export class ObsidianMapper {
 
     // Remove [id::xxx] (backwards compat for tasks indexed before migration)
     cleaned = cleaned.replace(/\[id::[^\]]+\]/g, '');
-    // Remove hashtags (but not # followed by numbers like #42)
-    cleaned = cleaned.replace(/#[a-zA-Z][\w-]*/g, '');
+    // Remove hashtags, including nested tags like #work/sample_project
+    // (but not # followed by numbers like #42)
+    cleaned = cleaned.replace(/#[a-zA-Z][\w/-]*/g, '');
     // Clean up extra whitespace
     cleaned = cleaned.replace(/\s+/g, ' ').trim();
 


### PR DESCRIPTION
## Summary

Fixes #114 — tasks with nested tags (e.g. `#work/sample_project`) accumulate duplicate/corrupted tags on every sync.

**Root cause:** `ObsidianMapper.cleanDescription()` stripped inline tags with `/#[a-zA-Z][\w-]*/g`. The character class `[\w-]` excludes `/`, so a nested tag like `#work/sample_project` matched only `#work` — leaving `/sample_project` stranded in the title while the real tag was correctly re-emitted from `task.tags`. The orphaned fragment has no `#`, so the next parse can't recognize it as a tag and never cleans it, while a fresh fragment is added from the re-emitted tag. The line grows on every sync:

| sync | resulting line |
|------|----------------|
| input | `- [ ] #wtd #work/sample_project #work/java Do Somthing` |
| after 1 | `- [ ] /sample_project /java Do Somthing #work/sample_project #work/java 🆔 … #wtd` |
| after 2 | `- [ ] /sample_project /java Do Somthing /sample_project /java …` |

**Fix:** add `/` to the character class so nested tags strip fully. The leading `[a-zA-Z]` is unchanged, so `#42`-style numeric pseudo-tags are still preserved.

```diff
- cleaned = cleaned.replace(/#[a-zA-Z][\w-]*/g, '');
+ cleaned = cleaned.replace(/#[a-zA-Z][\w/-]*/g, '');
```

## Test

Added `should clean nested tags from description` to the `toCommonTask` block in `src/tasks/obsidianMapper.test.ts`, asserting the title is clean and nested tags are preserved in the tag list.

## Verification

- `npm test` → 23 suites / 484 tests pass (unit + E2E), coverage thresholds met
- `npm run lint` → clean
- `tsc -noEmit` → clean

## Note on the commenter's variant

The commenter's `#house` → `#house #house…` case uses a *non-nested* tag, which strips cleanly in-plugin — that accumulation additionally requires an external client (Apple Reminders) folding the category into the task SUMMARY. This PR fixes the titular plugin bug and the in-plugin accumulation; the Apple Reminders interaction is a separate follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)