### PR TITLE
fix(tasks): readable YYYYMMDD-xxxx task IDs with vault-wide re-roll (#115)

### DIFF
--- a/src/caldav/calDAVClientDirect.ts
+++ b/src/caldav/calDAVClientDirect.ts
@@ -199,7 +199,7 @@ export class CalDAVClientDirect implements CalDAVClient {
     });
 
     if (response.status !== 201 && response.status !== 204) {
-      throw new Error(`Create VTODO failed: ${response.status} ${response.text}`);
+      throw new Error(`Create VTODO failed: ${response.status} for ${uid} at ${url} ${response.text}`);
     }
 
   }

--- a/src/sync/obsidianAdapter.test.ts
+++ b/src/sync/obsidianAdapter.test.ts
@@ -134,6 +134,35 @@ describe('ObsidianAdapter', () => {
     });
   });
 
+  describe('fetchTasks ID generation', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('never generates an ID owned by a task outside the sync filter (#115)', async () => {
+      const draws = [new Uint8Array([0x12, 0x34]), new Uint8Array([0xab, 0xcd])];
+      jest.spyOn(crypto, 'getRandomValues').mockImplementation(<T,>(arr: T): T => {
+        (arr as Uint8Array).set(draws.shift()!);
+        return arr;
+      });
+      const now = new Date();
+      const today = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`;
+
+      const unfiltered = makeTask({ id: `${today}-1234`, tags: ['#other'] });
+      const newTask = makeTask({ id: '', tags: ['#sync'] });
+      const wrapper = {
+        ...dummyWrapper,
+        getAllTasksWithBody: jest.fn().mockResolvedValue([withBody(unfiltered), withBody(newTask)]),
+        filterByTag: jest.fn().mockImplementation((inputs: TaskWithBody[]) =>
+          inputs.filter(({ task }) => task.tags.includes('#sync'))),
+      } as unknown as ObsidianTasksWrapper;
+      const adapter = new ObsidianAdapter(wrapper, defaultSettings);
+
+      const tasks = await adapter.fetchTasks();
+
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].uid).toBe(`${today}-abcd`);
+    });
+  });
+
   describe('findOriginalTask', () => {
     it('should return the original ObsidianTask after normalize', () => {
       const adapter = new ObsidianAdapter(dummyWrapper, defaultSettings);

--- a/src/sync/obsidianAdapter.ts
+++ b/src/sync/obsidianAdapter.ts
@@ -29,6 +29,9 @@ export class ObsidianAdapter {
 	private wrapper: ObsidianTasksWrapper;
 	private settings: ObsidianSyncSettings;
 	private tasksById = new Map<string, ObsidianTask>();
+	// Every task ID in the vault (not just this calendar's), so generated IDs
+	// can never collide with a task another calendar or filter owns (#115).
+	private usedIds = new Set<string>();
 
 	constructor(
 		wrapper: ObsidianTasksWrapper,
@@ -46,6 +49,11 @@ export class ObsidianAdapter {
 
 	async fetchTasks(): Promise<CommonTask[]> {
 		const allInputs = await this.wrapper.getAllTasksWithBody();
+		this.usedIds = new Set(
+			allInputs
+				.map(({ task }) => this.wrapper.extractId(task))
+				.filter((id): id is string => id !== null),
+		);
 		const filtered = this.wrapper.filterByTag(allInputs, this.settings.syncTag);
 		const normalized = this.normalize(
 			filtered,
@@ -76,7 +84,7 @@ export class ObsidianAdapter {
 		this.tasksById = new Map();
 
 		for (const { task, body } of inputs) {
-			const taskId = extractId(task) ?? generateTaskId();
+			const taskId = extractId(task) ?? generateTaskId(this.usedIds);
 			this.tasksById.set(taskId, task);
 			const common = this.mapper.toCommonTask(task, taskId, body);
 
@@ -118,7 +126,7 @@ export class ObsidianAdapter {
 			try {
 				switch (change.type) {
 					case "create": {
-						const taskId = generateTaskId();
+						const taskId = generateTaskId(this.usedIds);
 						const taskWithId: CommonTask = {
 							...change.task,
 							uid: taskId,

--- a/src/sync/obsidianAdapter.ts
+++ b/src/sync/obsidianAdapter.ts
@@ -224,8 +224,9 @@ export class ObsidianAdapter {
 	}
 
 	/**
-	 * Write IDs back to vault for tasks that had in-memory IDs generated during normalize.
-	 * Only called after sync succeeds, so IDs are only persisted when sync completes.
+	 * Write IDs back to vault for tasks that had in-memory IDs generated during
+	 * normalize. Runs before the CalDAV push so a failed push retries with the
+	 * same identities instead of minting new IDs and duplicating tasks.
 	 */
 	async writeBackIds(obsidianTasks: CommonTask[]): Promise<void> {
 		const { format, globalFilter } = await this.wrapper.getTasksPluginConfig();

--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -1809,4 +1809,27 @@ describe('SyncEngine', () => {
       expect(mockDeleteVTODOByUID).not.toHaveBeenCalled();
     });
   });
+
+  describe('id write-back happens before the CalDAV push', () => {
+    it('stamps generated IDs into the vault even when the CalDAV apply fails', async () => {
+      mockCreateVTODO.mockRejectedValue(new Error('Create VTODO failed: 412'));
+      mockGetAllTasksWithBody.mockResolvedValue([{
+        task: makeObsidianTask({
+          description: 'New local task',
+          id: '',
+          originalMarkdown: '- [ ] New local task #sync',
+        }),
+        body: '',
+      }]);
+
+      const engine = new SyncEngine(new App(), makeCalendarMapping(), makeSettings());
+      await engine.initialize();
+      const result = await engine.sync();
+
+      expect(result.success).toBe(false);
+      const stamped = mockUpdateTaskInVault.mock.calls
+        .filter(([, content]) => typeof content === 'string' && content.includes('🆔 '));
+      expect(stamped).toHaveLength(1);
+    });
+  });
 });

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -90,8 +90,11 @@ export class SyncEngine {
 			if (dryRun) return this.buildResult(applicable, obsidianTasks, caldavTasks, baseline, true, showProgress);
 
 			const { createdMappings, completionRemappings } = await this.obsidianAdapter.applyChanges(applicable.toObsidian);
-			await this.caldavAdapter.applyChanges(applicable.toCalDAV, idMapping);
+			// Stamp IDs before the CalDAV push: if the push fails, the vault
+			// keeps the identities, so the retry converges on the same UIDs
+			// instead of minting new ones and duplicating tasks.
 			await this.obsidianAdapter.writeBackIds(obsidianTasks);
+			await this.caldavAdapter.applyChanges(applicable.toCalDAV, idMapping);
 
 			this.updateIdMapping(idMapping, createdMappings, completionRemappings, applicable);
 			this.persistState(obsidianTasks, caldavTasks, applicable, idMapping);

--- a/src/utils/taskIdGenerator.test.ts
+++ b/src/utils/taskIdGenerator.test.ts
@@ -4,41 +4,56 @@ import {
   isValidTaskId
 } from './taskIdGenerator';
 
+function todayDatePart(): string {
+  const now = new Date();
+  return `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`;
+}
+
 describe('taskIdGenerator', () => {
   describe('generateTaskId', () => {
     afterEach(() => jest.restoreAllMocks());
 
-    it('generates a 10-character base32 id', () => {
-      expect(generateTaskId()).toMatch(/^[0-9a-hjkmnp-tv-z]{10}$/);
+    it('generates YYYYMMDD-xxxx with a 4-char hex suffix', () => {
+      expect(generateTaskId()).toMatch(/^\d{8}-[0-9a-f]{4}$/);
     });
 
-    it('shares a 3-character day prefix for ids generated the same day', () => {
-      jest.spyOn(Date, 'now').mockReturnValue(Date.UTC(2026, 5, 22, 9));
-
-      const first = generateTaskId();
-      const second = generateTaskId();
-
-      expect(first.slice(0, 3)).toBe(second.slice(0, 3));
+    it('uses the local calendar date, matching the legacy format', () => {
+      expect(generateTaskId().slice(0, 8)).toBe(todayDatePart());
     });
 
-    it('uses a lexicographically greater day prefix on a later day', () => {
-      const now = jest.spyOn(Date, 'now');
+    it('re-rolls when the candidate id is already in use', () => {
+      const draws = [new Uint8Array([0x12, 0x34]), new Uint8Array([0xab, 0xcd])];
+      jest.spyOn(crypto, 'getRandomValues').mockImplementation(<T,>(arr: T): T => {
+        (arr as Uint8Array).set(draws.shift()!);
+        return arr;
+      });
 
-      now.mockReturnValue(Date.UTC(2026, 0, 1));
-      const earlier = generateTaskId().slice(0, 3);
-      now.mockReturnValue(Date.UTC(2027, 0, 1));
-      const later = generateTaskId().slice(0, 3);
+      const used = new Set([`${todayDatePart()}-1234`]);
 
-      expect(later > earlier).toBe(true);
+      expect(generateTaskId(used)).toBe(`${todayDatePart()}-abcd`);
+    });
+
+    it('records the returned id in the used set', () => {
+      const used = new Set<string>();
+      const id = generateTaskId(used);
+      expect(used.has(id)).toBe(true);
     });
 
     it('generates unique ids for many tasks created the same day (issue #115)', () => {
-      jest.spyOn(Date, 'now').mockReturnValue(Date.UTC(2026, 5, 22, 9));
-
+      const used = new Set<string>();
       const ids = new Set<string>();
-      for (let i = 0; i < 500; i++) ids.add(generateTaskId());
+      for (let i = 0; i < 500; i++) ids.add(generateTaskId(used));
 
       expect(ids.size).toBe(500);
+    });
+
+    it('grows the suffix instead of looping forever when the day space is exhausted', () => {
+      const used = new Set<string>();
+      for (let i = 0; i < 65536; i++) {
+        used.add(`${todayDatePart()}-${i.toString(16).padStart(4, '0')}`);
+      }
+
+      expect(generateTaskId(used)).toMatch(/^\d{8}-[0-9a-f]{5,}$/);
     });
   });
 
@@ -61,26 +76,19 @@ describe('taskIdGenerator', () => {
   });
 
   describe('isValidTaskId', () => {
-    it('validates the new 10-character base32 format', () => {
-      expect(isValidTaskId('0s8k7p2qx9')).toBe(true);
+    it('validates the current 4-char hex suffix format', () => {
+      expect(isValidTaskId('20260703-a4f3')).toBe(true);
       expect(isValidTaskId(generateTaskId())).toBe(true);
     });
 
-    it('rejects a new-format id of the wrong length', () => {
-      expect(isValidTaskId('0s8k7p2qx')).toBe(false);   // 9 chars
-      expect(isValidTaskId('0s8k7p2qx9a')).toBe(false); // 11 chars
-    });
-
-    it('rejects a new-format id with ambiguous or uppercase chars', () => {
-      expect(isValidTaskId('0s8k7p2qxi')).toBe(false); // 'i' not in base32 alphabet
-      expect(isValidTaskId('0S8K7P2QX9')).toBe(false); // uppercase
-    });
-
-    it('validates the legacy YYYYMMDD-xxx format', () => {
+    it('validates the legacy 3-char hex suffix format', () => {
       expect(isValidTaskId('20250105-abc')).toBe(true);
       expect(isValidTaskId('20250105-000')).toBe(true);
-      expect(isValidTaskId('20250105-fff')).toBe(true);
       expect(isValidTaskId('19991231-123')).toBe(true);
+    });
+
+    it('validates longer suffixes from day-space overflow', () => {
+      expect(isValidTaskId('20260703-a4f3c')).toBe(true);
     });
 
     it('should reject invalid date format', () => {
@@ -91,7 +99,6 @@ describe('taskIdGenerator', () => {
 
     it('should reject invalid hex suffix', () => {
       expect(isValidTaskId('20250105-ab')).toBe(false);   // 2 chars
-      expect(isValidTaskId('20250105-abcd')).toBe(false); // 4 chars
       expect(isValidTaskId('20250105-xyz')).toBe(false);  // non-hex chars
       expect(isValidTaskId('20250105-ABC')).toBe(false);  // uppercase
     });

--- a/src/utils/taskIdGenerator.test.ts
+++ b/src/utils/taskIdGenerator.test.ts
@@ -6,29 +6,39 @@ import {
 
 describe('taskIdGenerator', () => {
   describe('generateTaskId', () => {
-    it('should generate ID in YYYYMMDD-xxx format', () => {
-      const id = generateTaskId();
-      expect(id).toMatch(/^\d{8}-[0-9a-f]{3}$/);
+    afterEach(() => jest.restoreAllMocks());
+
+    it('generates a 10-character base32 id', () => {
+      expect(generateTaskId()).toMatch(/^[0-9a-hjkmnp-tv-z]{10}$/);
     });
 
-    it('should generate IDs with current date', () => {
-      const id = generateTaskId();
-      const today = new Date();
-      const year = today.getFullYear();
-      const month = String(today.getMonth() + 1).padStart(2, '0');
-      const day = String(today.getDate()).padStart(2, '0');
-      const expectedPrefix = `${year}${month}${day}`;
+    it('shares a 3-character day prefix for ids generated the same day', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(Date.UTC(2026, 5, 22, 9));
 
-      expect(id.startsWith(expectedPrefix)).toBe(true);
+      const first = generateTaskId();
+      const second = generateTaskId();
+
+      expect(first.slice(0, 3)).toBe(second.slice(0, 3));
     });
 
-    it('should generate unique IDs', () => {
-      const ids = new Set();
-      for (let i = 0; i < 100; i++) {
-        ids.add(generateTaskId());
-      }
-      // Should have high uniqueness (allow for small chance of collision)
-      expect(ids.size).toBeGreaterThan(95);
+    it('uses a lexicographically greater day prefix on a later day', () => {
+      const now = jest.spyOn(Date, 'now');
+
+      now.mockReturnValue(Date.UTC(2026, 0, 1));
+      const earlier = generateTaskId().slice(0, 3);
+      now.mockReturnValue(Date.UTC(2027, 0, 1));
+      const later = generateTaskId().slice(0, 3);
+
+      expect(later > earlier).toBe(true);
+    });
+
+    it('generates unique ids for many tasks created the same day (issue #115)', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(Date.UTC(2026, 5, 22, 9));
+
+      const ids = new Set<string>();
+      for (let i = 0; i < 500; i++) ids.add(generateTaskId());
+
+      expect(ids.size).toBe(500);
     });
   });
 
@@ -51,7 +61,22 @@ describe('taskIdGenerator', () => {
   });
 
   describe('isValidTaskId', () => {
-    it('should validate correct format', () => {
+    it('validates the new 10-character base32 format', () => {
+      expect(isValidTaskId('0s8k7p2qx9')).toBe(true);
+      expect(isValidTaskId(generateTaskId())).toBe(true);
+    });
+
+    it('rejects a new-format id of the wrong length', () => {
+      expect(isValidTaskId('0s8k7p2qx')).toBe(false);   // 9 chars
+      expect(isValidTaskId('0s8k7p2qx9a')).toBe(false); // 11 chars
+    });
+
+    it('rejects a new-format id with ambiguous or uppercase chars', () => {
+      expect(isValidTaskId('0s8k7p2qxi')).toBe(false); // 'i' not in base32 alphabet
+      expect(isValidTaskId('0S8K7P2QX9')).toBe(false); // uppercase
+    });
+
+    it('validates the legacy YYYYMMDD-xxx format', () => {
       expect(isValidTaskId('20250105-abc')).toBe(true);
       expect(isValidTaskId('20250105-000')).toBe(true);
       expect(isValidTaskId('20250105-fff')).toBe(true);

--- a/src/utils/taskIdGenerator.ts
+++ b/src/utils/taskIdGenerator.ts
@@ -1,30 +1,39 @@
 /**
- * Generates unique, human-readable task IDs using timestamp-based format
- * Format: YYYYMMDD-xxx where xxx is a random 3-character hex string
+ * Generates compact, ULID-style task IDs: a 3-character day code followed by
+ * 7 characters of cryptographic randomness, all in Crockford-style base32.
  *
- * This provides:
- * - Human readability: dates are visible at a glance
- * - Sortability: lexicographic order matches chronological order
- * - Collision resistance: ~65k combinations per day
+ * - 10 characters total, opaque — carries no meaning beyond uniqueness
+ * - day code (days since 2024-01-01) keeps IDs lexicographically sortable by day
+ * - 35 random bits per day make same-day collisions negligible, fixing the
+ *   birthday-paradox duplicates of the old 12-bit YYYYMMDD-xxx scheme (#115)
  */
+
+// Crockford-style base32: no i/l/o/u, so IDs are unambiguous and file/URL-safe.
+const BASE32 = '0123456789abcdefghjkmnpqrstvwxyz';
+const MS_PER_DAY = 86_400_000;
+const EPOCH_DAY = Math.floor(Date.UTC(2024, 0, 1) / MS_PER_DAY);
+
+function toBase32(value: number, width: number): string {
+  let out = '';
+  for (let i = 0; i < width; i++) {
+    out = BASE32[value % 32] + out;
+    value = Math.floor(value / 32);
+  }
+  return out;
+}
 
 /**
- * Generate a timestamp-based task ID
- * @returns A task ID in format YYYYMMDD-xxx (e.g., 20250105-a4f)
+ * Generate a 10-character ULID-style task ID (e.g. "0s8k7p2qx9").
+ * @returns A task ID: 3-char day code + 7-char crypto-random base32 string
  */
 export function generateTaskId(): string {
-  const now = new Date();
+  const dayCode = toBase32(Math.floor(Date.now() / MS_PER_DAY) - EPOCH_DAY, 3);
 
-  // Format date as YYYYMMDD
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const day = String(now.getDate()).padStart(2, '0');
-  const datePart = `${year}${month}${day}`;
+  const bytes = crypto.getRandomValues(new Uint8Array(7));
+  let randomPart = '';
+  for (const byte of bytes) randomPart += BASE32[byte & 31];
 
-  // Generate 3-character random hex string
-  const randomPart = Math.floor(Math.random() * 4096).toString(16).padStart(3, '0');
-
-  return `${datePart}-${randomPart}`;
+  return dayCode + randomPart;
 }
 
 /**
@@ -47,10 +56,11 @@ export function extractTaskId(taskText: string): string | null {
 }
 
 /**
- * Validate task ID format
+ * Validate task ID format. Accepts the current 10-character base32 format and
+ * the legacy YYYYMMDD-xxx format, since old IDs remain valid in existing vaults.
  * @param id The task ID to validate
  * @returns true if valid, false otherwise
  */
 export function isValidTaskId(id: string): boolean {
-  return /^\d{8}-[0-9a-f]{3}$/.test(id);
+  return /^[0-9a-hjkmnp-tv-z]{10}$/.test(id) || /^\d{8}-[0-9a-f]{3}$/.test(id);
 }

--- a/src/utils/taskIdGenerator.ts
+++ b/src/utils/taskIdGenerator.ts
@@ -1,39 +1,47 @@
 /**
- * Generates compact, ULID-style task IDs: a 3-character day code followed by
- * 7 characters of cryptographic randomness, all in Crockford-style base32.
+ * Generates human-readable task IDs: YYYYMMDD-xxxx, a local calendar date and
+ * a 4-character random hex suffix.
  *
- * - 10 characters total, opaque — carries no meaning beyond uniqueness
- * - day code (days since 2024-01-01) keeps IDs lexicographically sortable by day
- * - 35 random bits per day make same-day collisions negligible, fixing the
- *   birthday-paradox duplicates of the old 12-bit YYYYMMDD-xxx scheme (#115)
+ * Uniqueness comes from the caller-supplied `usedIds` set, not from entropy
+ * alone: candidates already in the set are re-rolled, so same-vault collisions
+ * are impossible by construction (issue #115). The 65,536/day space only has
+ * to cover the cross-device window between generating an ID and syncing it.
  */
-
-// Crockford-style base32: no i/l/o/u, so IDs are unambiguous and file/URL-safe.
-const BASE32 = '0123456789abcdefghjkmnpqrstvwxyz';
-const MS_PER_DAY = 86_400_000;
-const EPOCH_DAY = Math.floor(Date.UTC(2024, 0, 1) / MS_PER_DAY);
-
-function toBase32(value: number, width: number): string {
-  let out = '';
-  for (let i = 0; i < width; i++) {
-    out = BASE32[value % 32] + out;
-    value = Math.floor(value / 32);
-  }
-  return out;
-}
 
 /**
- * Generate a 10-character ULID-style task ID (e.g. "0s8k7p2qx9").
- * @returns A task ID: 3-char day code + 7-char crypto-random base32 string
+ * Generate a task ID like "20260703-a4f3", guaranteed absent from `usedIds`.
+ * The returned ID is added to the set so sequential calls never collide.
+ * If a day's suffix space is ever exhausted, the suffix grows a character.
  */
-export function generateTaskId(): string {
-  const dayCode = toBase32(Math.floor(Date.now() / MS_PER_DAY) - EPOCH_DAY, 3);
+export function generateTaskId(usedIds?: Set<string>): string {
+  const datePart = localDatePart();
+  let width = 4;
+  let attempts = 0;
+  for (;;) {
+    const id = `${datePart}-${randomHex(width)}`;
+    if (!usedIds?.has(id)) {
+      usedIds?.add(id);
+      return id;
+    }
+    if (++attempts >= 16) {
+      width++;
+      attempts = 0;
+    }
+  }
+}
 
-  const bytes = crypto.getRandomValues(new Uint8Array(7));
-  let randomPart = '';
-  for (const byte of bytes) randomPart += BASE32[byte & 31];
+function localDatePart(): string {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${now.getFullYear()}${month}${day}`;
+}
 
-  return dayCode + randomPart;
+function randomHex(width: number): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(Math.ceil(width / 2)));
+  let out = '';
+  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
+  return out.slice(0, width);
 }
 
 /**
@@ -56,11 +64,9 @@ export function extractTaskId(taskText: string): string | null {
 }
 
 /**
- * Validate task ID format. Accepts the current 10-character base32 format and
- * the legacy YYYYMMDD-xxx format, since old IDs remain valid in existing vaults.
- * @param id The task ID to validate
- * @returns true if valid, false otherwise
+ * Validate task ID format: a date followed by a hex suffix — 3 chars in
+ * legacy IDs, 4 in current ones, longer only on day-space overflow.
  */
 export function isValidTaskId(id: string): boolean {
-  return /^[0-9a-hjkmnp-tv-z]{10}$/.test(id) || /^\d{8}-[0-9a-f]{3}$/.test(id);
+  return /^\d{8}-[0-9a-f]{3,}$/.test(id);
 }


### PR DESCRIPTION
## Summary

Fixes #115 / #127 — duplicate task IDs when creating many tasks in a single day, which could corrupt vaults (colliding UIDs made one task's update overwrite a different task in a different file).

## Approach

Uniqueness by construction, not by entropy: `generateTaskId(usedIds)` re-rolls any candidate already present in the set of **every task ID in the vault** (which `ObsidianAdapter` already holds at both generation sites — `normalize` and CalDAV-create). Same-vault collisions are now impossible, so the ID format can stay human-readable:

```
20260703-a4f3        (YYYYMMDD + 4 hex chars)
```

- Same look users already have, one char longer — the 65,536/day space is what the original code's comment always claimed (the implementation had 4,096)
- The set is built from **all** vault tasks, not the filtered subset, so calendar A can never mint an ID that calendar B's task owns (deterministic regression test included)
- If a day's suffix space is ever exhausted, the suffix grows a character instead of looping
- Legacy `YYYYMMDD-xxx` IDs stay valid and are never regenerated → no re-sync, no duplicates
- **IDs are stamped into the vault before the CalDAV push**: a failed push previously left generated IDs unwritten, so the next sync minted different IDs for the same tasks — any half-landed create became an orphan that bred duplicates. Persisting first makes retries converge on the same UIDs. Create failures also name the uid and url.

Server-side UID tracking was considered and deliberately dropped: the sync gate (#130) removes the overlapping-run race that produced stray server UIDs, and local-only tracking keeps the ID path simple. An earlier revision used an opaque 10-char ULID — dropped for readability once the re-roll check made large entropy unnecessary.

## Verification

- `npm test` — 544 passed / 28 suites (unit + Docker E2E)
- `npm run lint` + `npm run build` — clean
- Deterministic tests (mocked `crypto.getRandomValues`): collision → re-roll; day-space exhaustion (all 65,536 taken) → 5-char suffix; failed CalDAV push → IDs still stamped in the vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHA67SYTtMGnxDouEpK1Fv
