### PR TITLE
fix(sync): stop inline #tags duplicating across syncs

### DIFF
--- a/src/caldav/vtodoMapper.test.ts
+++ b/src/caldav/vtodoMapper.test.ts
@@ -1,5 +1,6 @@
 import { VTODOMapper, CalendarObject } from './vtodoMapper';
 import { CommonTask, TaskStatus, TaskPriority } from '../sync/types';
+import { ObsidianMapper } from '../tasks/obsidianMapper';
 
 describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
   let mapper: VTODOMapper;
@@ -1287,6 +1288,71 @@ END:VTODO`;
       const parsed = mapper.vtodoToTask(vtodo);
 
       expect(parsed.body).toBe('');
+    });
+  });
+
+  // Issue #114 (reopened): a SUMMARY carrying inline #tags (written by an
+  // older plugin version or another CalDAV client) kept the tag in both
+  // title and CATEGORIES, gaining one copy per sync. The title must never
+  // carry a #tag — inline tags move into tags[] so corrupted tasks heal.
+  describe('inline tags in SUMMARY (issue #114)', () => {
+    function vtodoWith(summary: string, categories?: string): CalendarObject {
+      const lines = [
+        'BEGIN:VTODO',
+        'UID:test-uid',
+        `SUMMARY:${summary}`,
+        'STATUS:NEEDS-ACTION',
+      ];
+      if (categories) lines.push(`CATEGORIES:${categories}`);
+      lines.push('END:VTODO');
+      return { data: lines.join('\n'), url: 'http://example.com/test.ics' };
+    }
+
+    it('strips an inline tag from the title and keeps it once in tags', () => {
+      const task = mapper.vtodoToTask(vtodoWith('Buy bread #house', 'house'));
+      expect(task.title).toBe('Buy bread');
+      expect(task.tags).toEqual(['house']);
+    });
+
+    it('heals a compounded SUMMARY with repeated tags', () => {
+      const task = mapper.vtodoToTask(
+        vtodoWith('Buy bread #house #house #house', 'house'),
+      );
+      expect(task.title).toBe('Buy bread');
+      expect(task.tags).toEqual(['house']);
+    });
+
+    it('moves an inline tag missing from CATEGORIES into tags', () => {
+      const task = mapper.vtodoToTask(vtodoWith('Water plants #garden'));
+      expect(task.title).toBe('Water plants');
+      expect(task.tags).toEqual(['garden']);
+    });
+
+    it('strips non-Latin inline tags', () => {
+      const task = mapper.vtodoToTask(
+        vtodoWith('Java study #프로그램/자바', '프로그램/자바'),
+      );
+      expect(task.title).toBe('Java study');
+      expect(task.tags).toEqual(['프로그램/자바']);
+    });
+
+    it('keeps issue references like #42 in the title', () => {
+      const task = mapper.vtodoToTask(vtodoWith('Fix #42 and #1'));
+      expect(task.title).toBe('Fix #42 and #1');
+      expect(task.tags).toEqual([]);
+    });
+
+    // A SUMMARY carrying the sync tag inline must not duplicate the
+    // trailing sync tag suffix when written back to markdown.
+    it('emits the sync tag once when SUMMARY carried it inline', () => {
+      const task = mapper.vtodoToTask(
+        vtodoWith('water the plants #sync', 'chores/garden'),
+      );
+      const md = new ObsidianMapper().toMarkdown({ ...task, uid: 'id-1' }, '#sync');
+      expect((md.match(/#sync/g) || []).length).toBe(1);
+      expect((md.match(/#chores\/garden/g) || []).length).toBe(1);
+      expect(md).toContain('water the plants');
+      expect(md).not.toContain('plants #sync #');
     });
   });
 });

--- a/src/caldav/vtodoMapper.ts
+++ b/src/caldav/vtodoMapper.ts
@@ -8,6 +8,7 @@ export interface CalendarObject {
 }
 
 import { CommonTask } from '../sync/types';
+import { extractInlineTags, stripInlineTags } from '../utils/inlineTags';
 
 /** Fields returned by vtodoToTask — everything except uid, which is extracted separately */
 type VTODOTaskFields = Omit<CommonTask, 'uid'>;
@@ -95,8 +96,13 @@ export class VTODOMapper {
     const vtodoMatch = unfolded.match(/BEGIN:VTODO[\s\S]*?END:VTODO/);
     const data = vtodoMatch ? vtodoMatch[0] : unfolded;
 
+    // Inline #tags in SUMMARY (written by older plugin versions or other
+    // clients) move into tags[], so corrupted tasks heal instead of gaining
+    // a duplicate tag on every sync — issue #114.
+    const summary = this.extractRawProperty(data, 'SUMMARY') || '';
+
     return {
-      title: this.extractRawProperty(data, 'SUMMARY') || 'Untitled Task',
+      title: stripInlineTags(summary) || 'Untitled Task',
       status: this.mapStatusFromVTODO(this.extractProperty(data, 'STATUS') || 'NEEDS-ACTION') as CommonTask['status'],
       dueDate: this.extractDateProperty(data, 'DUE'),
       scheduledDate: null,
@@ -104,7 +110,7 @@ export class VTODOMapper {
       completedDate: this.extractDateTimeProperty(data, 'COMPLETED'),
       priority: this.mapPriorityFromVTODO(this.extractProperty(data, 'PRIORITY') || '0') as CommonTask['priority'],
       recurrenceRule: this.extractProperty(data, 'RRULE') || '',
-      tags: this.extractCategories(data),
+      tags: this.dedupeTags([...this.extractCategories(data), ...extractInlineTags(summary)]),
       body: this.stripObsidianLinks(this.extractRawProperty(data, 'DESCRIPTION') || ''),
     };
   }
@@ -318,6 +324,17 @@ export class VTODOMapper {
     }
 
     return categories;
+  }
+
+  /** Case-insensitive, order-preserving dedupe — Obsidian treats tags case-insensitively. */
+  private dedupeTags(tags: string[]): string[] {
+    const seen = new Set<string>();
+    return tags.filter((tag) => {
+      const key = tag.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
   }
 
   /**

--- a/src/tasks/obsidianMapper.test.ts
+++ b/src/tasks/obsidianMapper.test.ts
@@ -84,6 +84,29 @@ describe('ObsidianMapper', () => {
       expect(mapper.toCommonTask(task, 'id').tags).toEqual(['sync', 'work', 'plain']);
     });
 
+    // Issue #114 (reopened): the strip regex only matched ASCII tags, so
+    // non-Latin tags survived in the title and were re-emitted from tags[]
+    // on every sync — one more copy per round-trip.
+    it('should clean non-Latin tags from description', () => {
+      const task = makeTask({
+        description: 'Java study #프로그램/자바 #работа #中文',
+        tags: ['#프로그램/자바', '#работа', '#中文'],
+      });
+      const common = mapper.toCommonTask(task, 'id');
+      expect(common.title).toBe('Java study');
+      expect(common.tags).toEqual(['프로그램/자바', 'работа', '中文']);
+    });
+
+    it('should clean accented tags without leaving stray characters', () => {
+      const task = makeTask({ description: 'Order beans #café', tags: ['#café'] });
+      expect(mapper.toCommonTask(task, 'id').title).toBe('Order beans');
+    });
+
+    it('should keep issue references like #42 in the title', () => {
+      const task = makeTask({ description: 'Fix #42 and #1', tags: [] });
+      expect(mapper.toCommonTask(task, 'id').title).toBe('Fix #42 and #1');
+    });
+
     it('should format moment-like dates', () => {
       const mockDate = { format: () => '2025-01-15' };
       const task = makeTask({
@@ -336,6 +359,56 @@ describe('ObsidianMapper', () => {
     it('dedupes case-insensitively when global filter equals sync tag', () => {
       const md = mapper.toMarkdown(baseTask, 'Task', 'emoji', '#task');
       expect((md.match(/#[Tt]ask/g) || []).length).toBe(1);
+    });
+  });
+
+  // Issue #114 (reopened): tag count must be stable across a full
+  // normalize → toMarkdown → re-parse → toMarkdown cycle. Before the fix,
+  // non-Latin tags survived in the title and gained a copy per cycle.
+  describe('round-trip tag stability', () => {
+    /** Simulate obsidian-tasks parsing an emitted markdown line back into a task. */
+    function reparse(markdown: string): ObsidianTask {
+      const description = markdown
+        .replace(/^- \[.\] /, '')
+        .replace(/🆔 \S+/u, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      const tags = Array.from(description.matchAll(/#\S+/gu), (m) => m[0]);
+      return makeTask({ description, tags });
+    }
+
+    function countOccurrences(haystack: string, needle: string): number {
+      return haystack.split(needle).length - 1;
+    }
+
+    it('keeps a Korean tag single across two sync cycles', () => {
+      let task = makeTask({
+        description: 'Java study #프로그램/자바 #sync',
+        tags: ['#프로그램/자바', '#sync'],
+      });
+
+      for (let cycle = 0; cycle < 2; cycle++) {
+        const common = mapper.toCommonTask(task, 'id-1');
+        expect(common.title).toBe('Java study');
+        const md = mapper.toMarkdown(common, '#sync');
+        expect(countOccurrences(md, '#프로그램/자바')).toBe(1);
+        task = reparse(md);
+      }
+    });
+
+    it('keeps an ASCII tag single across two sync cycles', () => {
+      let task = makeTask({
+        description: 'Clean up #house #sync',
+        tags: ['#house', '#sync'],
+      });
+
+      for (let cycle = 0; cycle < 2; cycle++) {
+        const common = mapper.toCommonTask(task, 'id-1');
+        expect(common.title).toBe('Clean up');
+        const md = mapper.toMarkdown(common, '#sync');
+        expect(countOccurrences(md, '#house')).toBe(1);
+        task = reparse(md);
+      }
     });
   });
 

--- a/src/tasks/obsidianMapper.ts
+++ b/src/tasks/obsidianMapper.ts
@@ -1,6 +1,7 @@
 import { RRule } from 'rrule';
 import { CommonTask, TaskStatus, TaskPriority } from '../sync/types';
 import { ObsidianTask } from './obsidianTasksWrapper';
+import { stripInlineTags } from '../utils/inlineTags';
 
 /**
  * Maps between obsidian-tasks Task objects and CommonTask.
@@ -173,17 +174,9 @@ export class ObsidianMapper {
    * Clean description by removing metadata that belongs in other fields.
    */
   private cleanDescription(description: string): string {
-    let cleaned = description;
-
     // Remove [id::xxx] (backwards compat for tasks indexed before migration)
-    cleaned = cleaned.replace(/\[id::[^\]]+\]/g, '');
-    // Remove hashtags, including nested tags like #work/sample_project
-    // (but not # followed by numbers like #42)
-    cleaned = cleaned.replace(/#[a-zA-Z][\w/-]*/g, '');
-    // Clean up extra whitespace
-    cleaned = cleaned.replace(/\s+/g, ' ').trim();
-
-    return cleaned;
+    const withoutId = description.replace(/\[id::[^\]]+\]/g, '');
+    return stripInlineTags(withoutId);
   }
 
   private cleanTags(tags: string[]): string[] {

--- a/src/utils/inlineTags.ts
+++ b/src/utils/inlineTags.ts
@@ -1,0 +1,19 @@
+/**
+ * Inline #tag handling shared by both mappers (issue #114). A CommonTask
+ * title must never carry a #tag — tags live in `tags[]` and are re-emitted
+ * on serialization, so a tag left in the title gains a copy every sync.
+ *
+ * Matches tags in any script (#house, #프로그램/자바, #café), including
+ * nested tags (#work/java), but not numeric references like #42.
+ */
+const INLINE_TAG = /#[\p{L}][\p{L}\p{N}_/-]*/gu;
+
+/** Remove inline tags and collapse the whitespace they leave behind. */
+export function stripInlineTags(text: string): string {
+  return text.replace(INLINE_TAG, '').replace(/\s+/g, ' ').trim();
+}
+
+/** Inline tags found in the text, without the # prefix. */
+export function extractInlineTags(text: string): string[] {
+  return Array.from(text.matchAll(INLINE_TAG), (m) => m[0].slice(1));
+}


### PR DESCRIPTION
Fixes #114 (reopened).

## Root cause — two mechanisms feeding each other

1. **ASCII-only strip regex.** `cleanDescription` in `obsidianMapper.ts` used `/#[a-zA-Z][\w/-]*/g`, which only matches tags starting with an ASCII letter. Non-Latin tags (`#프로그램/자바`, Cyrillic, Chinese) survived in the title and were re-emitted from `tags[]` in `toMarkdown` — one more copy per sync. Accented tags left stray characters (`#café` → `é`). This is why the English case looked fixed while Korean still broke.

2. **Raw CalDAV title write-back.** `vtodoToTask` pulled `SUMMARY` raw into `title` while the same tag lived in `CATEGORIES`, and `toMarkdown` emitted the title with no re-clean. Once a SUMMARY carried an inline `#tag` (older plugin version, other CalDAV clients), each round-trip appended a copy (`#house #house #house…`, doubled `#sync`).

## Fix

Invariant: **a `CommonTask` title never carries a `#tag`.** Enforced at both normalize seams via a shared helper (`src/utils/inlineTags.ts`):

- Strip regex is now Unicode-aware: `/#[\p{L}][\p{L}\p{N}_/-]*/gu` — all scripts, nested tags; keeps `#42` / `#1`.
- `vtodoToTask` strips inline tags from `SUMMARY` and merges them into `tags[]` (case-insensitive, order-preserving dedupe), so **already-corrupted tasks heal on the next sync** instead of compounding: the healed title is pushed back and the server SUMMARY is rewritten clean.

The sync tag takes its usual reserved-tag path in `toMarkdown` (emitted once as the trailing suffix), so an inline `#sync` in SUMMARY converges to a single tag.

## Tests (TDD — all written failing first)

- Unicode/accented/nested tag stripping; `#42`/`#1` kept (obsidianMapper).
- Round-trip stability: tag count stays 1 across two full normalize → toMarkdown → re-parse cycles, Korean and ASCII (obsidianMapper).
- SUMMARY heal: inline tag moved to tags once, compounded `#house #house #house` heals, non-Latin inline tags, `#42` kept, and a SUMMARY carrying the sync tag inline emits it once after write-back (vtodoMapper).

`npm test` (unit + Docker E2E): 520 passed, 26 suites. Lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbGTKYisCxE7aJNBSJSAnM