### PR TITLE
feat(sync): one sync at a time, with live progress in the status bar

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -223,11 +223,11 @@ export default class CalDAVSyncPlugin extends Plugin {
 
 	/**
 	 * Single entry point for every sync run: holds the gate so runs never
-	 * overlap, and shows progress in the status bar while one is active.
+	 * overlap, and clears the status bar when one finishes. The sync loops
+	 * paint progress via syncProgress().
 	 */
 	private async runSync<T>(fn: () => Promise<T>): Promise<T | null> {
 		return this.syncGate.run(async () => {
-			this.statusBar.setText('CalDAV: syncing…');
 			try {
 				return await fn();
 			} finally {

--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,8 @@ import { calendarLabel } from './src/utils/calendarLabel';
 import { loadSettingsFrom, resolveSettings } from './src/utils/settingsLoader';
 import { extractTaskId, isValidTaskId } from './src/utils/taskIdGenerator';
 import { SyncEngine, SyncResult } from './src/sync/syncEngine';
+import { SyncGate } from './src/sync/syncGate';
+import { SyncProgress } from './src/sync/progress';
 import { dumpCalDAVRequests } from './src/caldav/requestDumper';
 import { SyncResultModal } from './src/ui/syncResultModal';
 import { BrowseCalendarsModal } from './src/ui/browseCalendarsModal';
@@ -16,8 +18,11 @@ export default class CalDAVSyncPlugin extends Plugin {
 	private syncEngines: SyncEngine[] = [];
 	private autoSync: AutoSyncScheduler | null = null;
 	private loadFailure: string | null = null;
+	private syncGate = new SyncGate();
+	private statusBar!: HTMLElement;
 
 	async onload() {
+		this.statusBar = this.addStatusBarItem();
 		await this.safeLoad();
 
 		this.addCommand({
@@ -64,6 +69,7 @@ export default class CalDAVSyncPlugin extends Plugin {
 					return;
 				}
 				const results = await this.syncAllEngines(false);
+				if (results === null) return;
 				new SyncResultModal(this.app, results, false).open();
 			}
 		});
@@ -77,7 +83,8 @@ export default class CalDAVSyncPlugin extends Plugin {
 					return;
 				}
 				const results = await this.syncAllEngines(true);
-				new SyncResultModal(this.app, results, true, () => this.syncAllEngines(false)).open();
+				if (results === null) return;
+				new SyncResultModal(this.app, results, true, async () => await this.syncAllEngines(false) ?? []).open();
 			}
 		});
 
@@ -214,16 +221,62 @@ export default class CalDAVSyncPlugin extends Plugin {
 		new Notice(`Skipped ${skipped.length} incomplete ${noun}: ${skipped.join('; ')}. Configure in settings.`, 8000);
 	}
 
-	private async syncAll(): Promise<void> {
-		for (const engine of this.syncEngines) {
-			await engine.sync({ background: true });
-		}
+	/**
+	 * Single entry point for every sync run: holds the gate so runs never
+	 * overlap, and shows progress in the status bar while one is active.
+	 */
+	private async runSync<T>(fn: () => Promise<T>): Promise<T | null> {
+		return this.syncGate.run(async () => {
+			this.statusBar.setText('CalDAV: syncing…');
+			try {
+				return await fn();
+			} finally {
+				this.statusBar.setText('');
+			}
+		});
 	}
 
-	private async syncAllEngines(dryRun: boolean): Promise<SyncResult[]> {
-		const results: SyncResult[] = [];
-		for (const engine of this.syncEngines) {
-			results.push(await engine.sync({ dryRun }));
+	private syncProgress(progress?: SyncProgress): void {
+		this.statusBar.empty();
+		this.statusBar.createSpan({ text: 'CalDAV:' });
+		if (!progress) {
+			this.statusBar.createSpan({ text: ' syncing…' });
+			return;
+		}
+		this.renderDirection('←', progress.pullDone, progress.pullTotal);
+		this.renderDirection('→', progress.pushDone, progress.pushTotal);
+	}
+
+	private renderDirection(arrow: string, done: number, total: number): void {
+		if (total === 0) return;
+		this.statusBar.createSpan({ text: ` ${arrow} ` });
+		const bar = this.statusBar.createEl('progress', { cls: 'caldav-sync-progress' });
+		bar.max = total;
+		bar.value = done;
+		this.statusBar.createSpan({ text: ` ${done}/${total}` });
+	}
+
+	private async syncAll(): Promise<void> {
+		// A tick that lands mid-sync skips silently; the next one catches up.
+		await this.runSync(async () => {
+			for (const engine of this.syncEngines) {
+				this.syncProgress();
+				await engine.sync({ background: true, onProgress: (p) => this.syncProgress(p) });
+			}
+		});
+	}
+
+	private async syncAllEngines(dryRun: boolean): Promise<SyncResult[] | null> {
+		const results = await this.runSync(async () => {
+			const out: SyncResult[] = [];
+			for (const engine of this.syncEngines) {
+				this.syncProgress();
+				out.push(await engine.sync({ dryRun, onProgress: (p) => this.syncProgress(p) }));
+			}
+			return out;
+		});
+		if (results === null) {
+			new Notice('Sync already running — wait for it to finish.');
 		}
 		return results;
 	}

--- a/src/sync/caldavAdapter.ts
+++ b/src/sync/caldavAdapter.ts
@@ -89,8 +89,9 @@ export class CalDAVAdapter {
 
   /**
    * Apply a set of sync changes to the CalDAV server.
+   * `onApplied` is called after each change is processed.
    */
-  async applyChanges(changes: SyncChange[], idMapping: IdMapping): Promise<void> {
+  async applyChanges(changes: SyncChange[], idMapping: IdMapping, onApplied?: () => void): Promise<void> {
     for (const change of changes) {
       const caldavUID = this.resolveCaldavUid(change.task.uid, idMapping);
 
@@ -131,6 +132,7 @@ export class CalDAVAdapter {
         case 'reconcile':
           break;
       }
+      onApplied?.();
     }
   }
 

--- a/src/sync/obsidianAdapter.ts
+++ b/src/sync/obsidianAdapter.ts
@@ -99,9 +99,11 @@ export class ObsidianAdapter {
 
 	/**
 	 * Apply sync changes to the Obsidian vault (creates, updates, deletes).
+	 * `onApplied` is called after each change is processed.
 	 */
 	async applyChanges(
 		changes: SyncChange[],
+		onApplied?: () => void,
 	): Promise<ApplyChangesResult> {
 		const createdMappings: Array<{
 			taskId: string;
@@ -210,6 +212,7 @@ export class ObsidianAdapter {
 					error,
 				);
 			}
+			onApplied?.();
 		}
 
 		return { createdMappings, completionRemappings };

--- a/src/sync/progress.ts
+++ b/src/sync/progress.ts
@@ -1,0 +1,7 @@
+/** Counts of applied vs pending changes for one sync run, per direction. */
+export interface SyncProgress {
+  pullDone: number;
+  pullTotal: number;
+  pushDone: number;
+  pushTotal: number;
+}

--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -4,6 +4,7 @@ import { CalDAVSettings, CalendarMapping, DEFAULT_CALDAV_SETTINGS, IdMapping } f
 import { CalendarObject } from '../caldav/vtodoMapper';
 import { ObsidianTask } from '../tasks/obsidianTasksWrapper';
 import { CommonTask } from './types';
+import { SyncProgress } from './progress';
 
 // --- Helpers ---
 
@@ -1807,6 +1808,34 @@ describe('SyncEngine', () => {
       expect(result.success).toBe(true);
       expect(result.deleted.toObsidian).toBe(1);
       expect(mockDeleteVTODOByUID).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sync progress reporting', () => {
+    it('reports pull/push totals and per-change progress', async () => {
+      // One pull (server task unknown to the vault) and one push (vault task
+      // unknown to the server).
+      mockFetchVTODOs.mockResolvedValue([{
+        data: buildVTODO('server-task-uid', 'Incoming task'),
+        url: 'https://caldav.example.com/cal/server-task-uid.ics',
+        etag: 'e1',
+      }]);
+      mockGetAllTasksWithBody.mockResolvedValue([{
+        task: makeObsidianTask({
+          description: 'Outgoing task',
+          originalMarkdown: '- [ ] Outgoing task [id::20250101-abc] #sync',
+        }),
+        body: '',
+      }]);
+
+      const updates: SyncProgress[] = [];
+      const engine = new SyncEngine(new App(), makeCalendarMapping(), makeSettings());
+      await engine.initialize();
+      const result = await engine.sync({ onProgress: (p) => updates.push(p) });
+
+      expect(result.success).toBe(true);
+      expect(updates[0]).toEqual({ pullDone: 0, pullTotal: 1, pushDone: 0, pushTotal: 1 });
+      expect(updates[updates.length - 1]).toEqual({ pullDone: 1, pullTotal: 1, pushDone: 1, pushTotal: 1 });
     });
   });
 });

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -7,6 +7,7 @@ import { CalDAVAdapter } from "./caldavAdapter";
 import { ObsidianAdapter } from "./obsidianAdapter";
 import { diff } from "./diff";
 import { applicableChanges } from "./applicableChanges";
+import { SyncProgress } from "./progress";
 import { CommonTask, Conflict, ConflictStrategy, SyncChange } from "./types";
 import { storageIdForCalendar } from "../utils/calendarStorageId";
 import { calendarLabel } from "../utils/calendarLabel";
@@ -35,6 +36,8 @@ export interface SyncOptions {
 	dryRun?: boolean;
 	/** Sync was triggered automatically (not by an explicit user command). */
 	background?: boolean;
+	/** Called with updated counts as each change is applied. */
+	onProgress?: (progress: SyncProgress) => void;
 }
 
 export class SyncEngine {
@@ -71,7 +74,7 @@ export class SyncEngine {
 		return true;
 	}
 
-	async sync({ dryRun = false, background = false }: SyncOptions = {}): Promise<SyncResult> {
+	async sync({ dryRun = false, background = false, onProgress }: SyncOptions = {}): Promise<SyncResult> {
 		try {
 			const showProgress = !background || this.settings.showAutoSyncNotifications;
 			if (showProgress) {
@@ -89,8 +92,29 @@ export class SyncEngine {
 
 			if (dryRun) return this.buildResult(applicable, obsidianTasks, caldavTasks, baseline, true, showProgress);
 
-			const { createdMappings, completionRemappings } = await this.obsidianAdapter.applyChanges(applicable.toObsidian);
-			await this.caldavAdapter.applyChanges(applicable.toCalDAV, idMapping);
+			const progress: SyncProgress = {
+				pullDone: 0,
+				pullTotal: applicable.toObsidian.length,
+				pushDone: 0,
+				pushTotal: applicable.toCalDAV.length,
+			};
+			onProgress?.({ ...progress });
+
+			const { createdMappings, completionRemappings } = await this.obsidianAdapter.applyChanges(
+				applicable.toObsidian,
+				() => {
+					progress.pullDone++;
+					onProgress?.({ ...progress });
+				},
+			);
+			await this.caldavAdapter.applyChanges(
+				applicable.toCalDAV,
+				idMapping,
+				() => {
+					progress.pushDone++;
+					onProgress?.({ ...progress });
+				},
+			);
 			await this.obsidianAdapter.writeBackIds(obsidianTasks);
 
 			this.updateIdMapping(idMapping, createdMappings, completionRemappings, applicable);

--- a/src/sync/syncGate.test.ts
+++ b/src/sync/syncGate.test.ts
@@ -1,0 +1,34 @@
+import { SyncGate } from './syncGate';
+
+describe('SyncGate', () => {
+  it('runs the function and returns its result', async () => {
+    const gate = new SyncGate();
+    expect(await gate.run(() => Promise.resolve('done'))).toBe('done');
+  });
+
+  it('returns null for a run attempted while another is in flight', async () => {
+    const gate = new SyncGate();
+    let release!: () => void;
+    const first = gate.run(() => new Promise<string>(resolve => {
+      release = () => resolve('first');
+    }));
+
+    const second = await gate.run(() => Promise.resolve('second'));
+
+    expect(second).toBeNull();
+    release();
+    expect(await first).toBe('first');
+  });
+
+  it('allows a new run after the previous one completes', async () => {
+    const gate = new SyncGate();
+    await gate.run(() => Promise.resolve('first'));
+    expect(await gate.run(() => Promise.resolve('second'))).toBe('second');
+  });
+
+  it('releases the gate when the function throws', async () => {
+    const gate = new SyncGate();
+    await expect(gate.run(() => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+    expect(await gate.run(() => Promise.resolve('after'))).toBe('after');
+  });
+});

--- a/src/sync/syncGate.ts
+++ b/src/sync/syncGate.ts
@@ -1,0 +1,18 @@
+/**
+ * Allows one sync run at a time. A run attempted while another is in flight
+ * gets null back instead of a second, racing run — overlapping syncs can
+ * each see the same unsynced task and double-create it.
+ */
+export class SyncGate {
+  private running = false;
+
+  async run<T>(fn: () => Promise<T>): Promise<T | null> {
+    if (this.running) return null;
+    this.running = true;
+    try {
+      return await fn();
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -239,3 +239,23 @@
   align-self: flex-start;
   margin-top: var(--size-4-2);
 }
+
+/* Status bar sync progress */
+
+.caldav-sync-progress {
+  width: 60px;
+  height: 6px;
+  vertical-align: middle;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.caldav-sync-progress::-webkit-progress-bar {
+  background: var(--background-modifier-border);
+  border-radius: 3px;
+}
+
+.caldav-sync-progress::-webkit-progress-value {
+  background: var(--interactive-accent);
+  border-radius: 3px;
+}


### PR DESCRIPTION
## Summary

Two coupled sync-run improvements, extracted from the 2026-07-03 testing session.

**Only one sync at a time (`SyncGate`).** Overlapping runs each see the same unsynced task and double-create it — the #105-style 412 race, reproducible by triggering manual syncs in quick succession. All entry points (commands, dry-run apply, auto-sync ticks) route through one gate: a blocked manual attempt gets "Sync already running — wait for it to finish.", a blocked auto tick skips silently and the next one catches up.

**Live progress in the status bar.** `CalDAV: ← ▰▰▱▱ 3/100 → ▰▱▱▱ 1/50` — a native `<progress>` element per direction with done/total counts, updated as each change applies, themed via Obsidian CSS variables (`--interactive-accent` / `--background-modifier-border`). `SyncEngine` gets an `onProgress` callback in `SyncOptions`; both adapters report `onApplied` per change. Long syncs are no longer a silent wait — which is what tempted users into triggering the overlapping runs the gate now blocks.

## Verification

- `npm test` — 542 passed / 29 suites (unit + Docker E2E)
- `npm run lint` + `npm run build` — clean
- Manually exercised in a live vault against Nextcloud (bars update per change; second manual sync mid-run is refused; auto-sync tick mid-run skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHA67SYTtMGnxDouEpK1Fv