### PR TITLE
fix(caldav): DTSTART maps to scheduled date only; start date is local-only

### DIFF
--- a/src/caldav/vtodoMapper.test.ts
+++ b/src/caldav/vtodoMapper.test.ts
@@ -314,7 +314,7 @@ END:VTODO`;
 
       const task = mapper.vtodoToTask(vtodo);
 
-      expect(task.startDate).toBe('2025-01-10');
+      expect(task.scheduledDate).toBe('2025-01-10');
     });
 
     it('should map all VTODO statuses correctly', () => {
@@ -884,7 +884,7 @@ END:VTODO`;
 
       // Dates should be identical after round-trip
       expect(roundTrippedTask.dueDate).toBe('2026-02-11');
-      expect(roundTrippedTask.startDate).toBe('2026-02-10');
+      expect(roundTrippedTask.scheduledDate).toBe('2026-02-10');
     });
 
     it('should handle dates consistently across multiple syncs', () => {
@@ -1003,7 +1003,7 @@ END:VTODO`;
       };
 
       const task = mapper.vtodoToTask(vtodo);
-      expect(task.startDate).toBe('2026-02-14');
+      expect(task.scheduledDate).toBe('2026-02-14');
     });
 
     it('should still parse VALUE=DATE format', () => {
@@ -1088,7 +1088,7 @@ END:VTODO`;
 
       // TZID dates should extract date portion
       expect(task.dueDate).toBe('2026-02-14');
-      expect(task.startDate).toBe('2026-02-14');
+      expect(task.scheduledDate).toBe('2026-02-14');
 
       // Other properties should parse normally
       expect(task.status).toBe('TODO');
@@ -1125,7 +1125,7 @@ END:VTODO`;
       // Parse TZID dates
       const task = mapper.vtodoToTask(vtodo);
       expect(task.dueDate).toBe('2026-03-15');
-      expect(task.startDate).toBe('2026-03-10');
+      expect(task.scheduledDate).toBe('2026-03-10');
 
       // Round-trip: convert back to VTODO (will use VALUE=DATE format)
       const vtodoOut = mapper.taskToVTODO(task, 'round-trip-tzid');
@@ -1135,7 +1135,7 @@ END:VTODO`;
       // Parse again — dates should be stable
       const task2 = mapper.vtodoToTask({ data: vtodoOut, etag: 'e2', url: 'http://test' });
       expect(task2.dueDate).toBe('2026-03-15');
-      expect(task2.startDate).toBe('2026-03-10');
+      expect(task2.scheduledDate).toBe('2026-03-10');
     });
   });
 
@@ -1353,6 +1353,63 @@ END:VTODO`;
       expect((md.match(/#chores\/garden/g) || []).length).toBe(1);
       expect(md).toContain('water the plants');
       expect(md).not.toContain('plants #sync #');
+    });
+  });
+
+  describe('DTSTART maps to scheduledDate only (start date is local-only)', () => {
+    const baseTask: Omit<CommonTask, 'uid'> = {
+      title: 'Date mapping',
+      status: 'TODO',
+      dueDate: null,
+      scheduledDate: null,
+      startDate: null,
+      completedDate: null,
+      priority: 'none',
+      recurrenceRule: '',
+      tags: [],
+      body: '',
+    };
+
+    function roundTrip(task: Omit<CommonTask, 'uid'>) {
+      const data = mapper.taskToVTODO(task, 'rt-uid');
+      return mapper.vtodoToTask({ data, url: 'http://x/rt-uid.ics', etag: 'e' });
+    }
+
+    it('writes DTSTART from scheduledDate even when startDate is also set', () => {
+      const ics = mapper.taskToVTODO(
+        { ...baseTask, startDate: '2026-07-01', scheduledDate: '2026-07-10' },
+        'uid-1',
+      );
+      expect(ics).toContain('DTSTART;VALUE=DATE:20260710');
+    });
+
+    it('does not write DTSTART for a start-only task', () => {
+      const ics = mapper.taskToVTODO({ ...baseTask, startDate: '2026-07-01' }, 'uid-1');
+      expect(ics).not.toContain('DTSTART');
+    });
+
+    it('round-trips a scheduled-only task back to scheduledDate', () => {
+      const back = roundTrip({ ...baseTask, scheduledDate: '2026-07-10' });
+      expect(back.scheduledDate).toBe('2026-07-10');
+      expect(back.startDate).toBeNull();
+    });
+
+    it('maps DTSTART written by another client to scheduledDate', () => {
+      const data = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'BEGIN:VTODO',
+        'UID:other-client',
+        'SUMMARY:From another app',
+        'DTSTART;VALUE=DATE:20260710',
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      const back = mapper.vtodoToTask({ data, url: 'http://x/o.ics', etag: 'e' });
+
+      expect(back.scheduledDate).toBe('2026-07-10');
+      expect(back.startDate).toBeNull();
     });
   });
 });

--- a/src/caldav/vtodoMapper.ts
+++ b/src/caldav/vtodoMapper.ts
@@ -55,10 +55,10 @@ export class VTODOMapper {
       lines.push(`DUE;VALUE=DATE:${this.formatDate(task.dueDate)}`);
     }
 
-    // Start date: prefer startDate (🛫) over scheduledDate (⏳) for DTSTART
-    const dtstart = task.startDate || task.scheduledDate;
-    if (dtstart) {
-      lines.push(`DTSTART;VALUE=DATE:${this.formatDate(dtstart)}`);
+    // DTSTART carries the scheduled date (⏳) — the field CalDAV clients plan
+    // by. The start date (🛫) has no CalDAV counterpart and never syncs.
+    if (task.scheduledDate) {
+      lines.push(`DTSTART;VALUE=DATE:${this.formatDate(task.scheduledDate)}`);
     }
 
     // Completed date
@@ -105,8 +105,8 @@ export class VTODOMapper {
       title: stripInlineTags(summary) || 'Untitled Task',
       status: this.mapStatusFromVTODO(this.extractProperty(data, 'STATUS') || 'NEEDS-ACTION') as CommonTask['status'],
       dueDate: this.extractDateProperty(data, 'DUE'),
-      scheduledDate: null,
-      startDate: this.extractDateProperty(data, 'DTSTART'),
+      scheduledDate: this.extractDateProperty(data, 'DTSTART'),
+      startDate: null,
       completedDate: this.extractDateTimeProperty(data, 'COMPLETED'),
       priority: this.mapPriorityFromVTODO(this.extractProperty(data, 'PRIORITY') || '0') as CommonTask['priority'],
       recurrenceRule: this.extractProperty(data, 'RRULE') || '',

--- a/src/sync/caldavAdapter.test.ts
+++ b/src/sync/caldavAdapter.test.ts
@@ -89,7 +89,7 @@ describe('CalDAVAdapter', () => {
 
       const task = adapter.toCommonTask(vtodo, 'id');
       expect(task.dueDate).toBe('2025-01-15');
-      expect(task.startDate).toBe('2025-01-10');
+      expect(task.scheduledDate).toBe('2025-01-10');
       expect(task.completedDate).toBe('2025-01-12');
     });
 

--- a/src/sync/diff.test.ts
+++ b/src/sync/diff.test.ts
@@ -67,6 +67,12 @@ describe('tasksEqual', () => {
     expect(tasksEqual(a, b)).toBe(false);
   });
 
+  it('ignores startDate differences — 🛫 is local-only and never syncs', () => {
+    const a = makeCommonTask({ startDate: '2026-07-01' });
+    const b = makeCommonTask({ startDate: null });
+    expect(tasksEqual(a, b)).toBe(true);
+  });
+
   it('should detect body change', () => {
     const a = makeCommonTask({ body: 'Note A' });
     const b = makeCommonTask({ body: 'Note B' });

--- a/src/sync/diff.ts
+++ b/src/sync/diff.ts
@@ -3,13 +3,14 @@ import { detectRecurrenceCompletion } from '../caldav/recurrenceDetector';
 
 /**
  * Compare two CommonTasks for equality across all synced fields.
+ * startDate (🛫) is intentionally excluded: it has no CalDAV counterpart and
+ * never syncs, so comparing it would make every 🛫 task re-sync forever.
  */
 export function tasksEqual(a: CommonTask, b: CommonTask): boolean {
   return (
     a.title === b.title &&
     a.status === b.status &&
     a.dueDate === b.dueDate &&
-    a.startDate === b.startDate &&
     a.scheduledDate === b.scheduledDate &&
     a.completedDate === b.completedDate &&
     a.priority === b.priority &&

--- a/src/sync/obsidianAdapter.test.ts
+++ b/src/sync/obsidianAdapter.test.ts
@@ -522,4 +522,44 @@ describe('ObsidianAdapter', () => {
       }])).rejects.toThrow('obsidian-tasks API not available');
     });
   });
+
+  describe('applyChanges preserves the local-only start date (🛫)', () => {
+    it('keeps 🛫 when a CalDAV update rewrites the task line', async () => {
+      const localTask = makeTask({
+        description: 'Task with start',
+        id: '20250101-abc',
+        startDate: '2026-07-01',
+        originalMarkdown: '- [ ] Task with start 🛫 2026-07-01 🆔 20250101-abc #sync',
+      });
+      const updateTaskInVault = jest.fn().mockResolvedValue(undefined);
+      const wrapper = {
+        ...dummyWrapper,
+        updateTaskInVault,
+      } as unknown as ObsidianTasksWrapper;
+      const adapter = new ObsidianAdapter(wrapper, defaultSettings);
+      adapter.normalize([withBody(localTask)], (task) => task.id || null);
+
+      await adapter.applyChanges([{
+        type: 'update',
+        task: {
+          uid: '20250101-abc',
+          title: 'Task with start (renamed on server)',
+          status: 'TODO',
+          dueDate: null,
+          startDate: null,
+          scheduledDate: null,
+          completedDate: null,
+          priority: 'none',
+          tags: [],
+          recurrenceRule: '',
+          body: '',
+        },
+      }]);
+
+      expect(updateTaskInVault).toHaveBeenCalledTimes(1);
+      const written = (updateTaskInVault.mock.calls[0] as [unknown, string])[1];
+      expect(written).toContain('🛫 2026-07-01');
+      expect(written).toContain('renamed on server');
+    });
+  });
 });

--- a/src/sync/obsidianAdapter.ts
+++ b/src/sync/obsidianAdapter.ts
@@ -159,8 +159,11 @@ export class ObsidianAdapter {
 							this.wrapper.findTaskById(change.task.uid);
 						if (!existingTask) continue;
 
+						// startDate (🛫) is local-only and never syncs; carry the
+						// vault's value so a CalDAV rewrite doesn't erase it.
+						const localStart = this.mapper.toCommonTask(existingTask, change.task.uid).startDate;
 						const markdown = this.mapper.toMarkdown(
-							change.task,
+							{ ...change.task, startDate: localStart },
 							this.settings.syncTag,
 							format,
 							globalFilter,

--- a/test/e2e/caldavAdapter.e2e.test.ts
+++ b/test/e2e/caldavAdapter.e2e.test.ts
@@ -137,7 +137,7 @@ describe('CalDAVAdapter E2E', () => {
       expect(tasks[0].title).toBe('Round trip test');
       expect(tasks[0].status).toBe('TODO');
       expect(tasks[0].dueDate).toBe('2025-07-01');
-      expect(tasks[0].startDate).toBe('2025-06-28');
+      expect(tasks[0].scheduledDate).toBe('2025-06-28');
       expect(tasks[0].priority).toBe('high');
       expect(tasks[0].tags).toEqual(['sync', 'test']);
     });

--- a/test/e2e/caldavClient.e2e.test.ts
+++ b/test/e2e/caldavClient.e2e.test.ts
@@ -184,7 +184,7 @@ describe('VTODO with VTIMEZONE and TZID dates', () => {
     const task = mapper.vtodoToTask(todos[0]);
     expect(task.title).toBe('Meeting prep');
     expect(task.dueDate).toBe('2025-06-15');
-    expect(task.startDate).toBe('2025-06-15');
+    expect(task.scheduledDate).toBe('2025-06-15');
   });
 });
 


### PR DESCRIPTION
## Summary

A task with a scheduled date (⏳) pushed to CalDAV came back as a start date (🛫): the push mapped `startDate || scheduledDate → DTSTART`, but the pull mapped `DTSTART → startDate` unconditionally. Beyond mutating the field, the asymmetry made every ⏳ task look changed on every sync cycle — a perpetual re-sync source.

## Design

An `X-OBSIDIAN-DATE-KIND` marker was considered and **rejected**: a stale marker misroutes genuine DTSTART edits made in other clients (drag the start date in Reminders → it lands as ⏳). The right move is to sync only what CalDAV actually has:

- **DTSTART ⇔ ⏳ scheduled** — the field daily-note workflows populate by default, and the one CalDAV task apps (Tasks.org, Nextcloud Tasks, Reminders) plan by. When both dates are set, DTSTART carries ⏳ — no selection, no ambiguity.
- **🛫 start is local-only** — it has no CalDAV counterpart and never syncs. Two guards make that safe:
  - excluded from `tasksEqual`, so a 🛫 task doesn't differ from its CalDAV twin forever (churn)
  - preserved when a CalDAV update rewrites the task line, so pulling an update can't erase it

Migration note: tasks previously pushed with a 🛫-derived DTSTART pull back as ⏳ once (the server genuinely holds a DTSTART; its origin is unknowable).

## Verification

- `npm test` — 555 passed / 29 suites (unit + Docker E2E, including a real-server round-trip of a ⏳-only task)
- `npm run lint` + `npm run build` — clean
- New contract tests: both-dates-set → DTSTART = ⏳; start-only → no DTSTART; third-party DTSTART → ⏳; startDate-only diff → equal; CalDAV update over a 🛫 task → 🛫 kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHA67SYTtMGnxDouEpK1Fv
