### PR TITLE
feat(settings): store CalDAV passwords in Obsidian secret storage

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,7 @@ import { CalDAVSettings, CalendarMapping, SyncDirection } from './src/types';
 import { describeIncompleteCalendar } from './src/utils/calendarConfig';
 import { calendarLabel } from './src/utils/calendarLabel';
 import { loadSettingsFrom, resolveSettings } from './src/utils/settingsLoader';
+import { clearStoredPassword, externalizePasswords, hasPasswordsToExternalize, hydratePasswords, SecretStore } from './src/utils/passwordStorage';
 import { extractTaskId, isValidTaskId } from './src/utils/taskIdGenerator';
 import { SyncEngine, SyncResult } from './src/sync/syncEngine';
 import { SyncGate } from './src/sync/syncGate';
@@ -144,8 +145,9 @@ export default class CalDAVSyncPlugin extends Plugin {
 	private async safeLoad(): Promise<void> {
 		try {
 			await this.loadSettings();
-			if (await runMigrations(this.app, this.settings)) {
-				await this.saveData(this.settings);
+			const migrated = await runMigrations(this.app, this.settings);
+			if (migrated || hasPasswordsToExternalize(this.settings, this.secretStore())) {
+				await this.persistSettings();
 			}
 		} catch (error) {
 			this.loadFailure = error instanceof Error ? error.message : String(error);
@@ -165,6 +167,12 @@ export default class CalDAVSyncPlugin extends Plugin {
 			loadData: () => this.loadData(),
 			dataFileExists: () => this.dataFileExists(),
 		});
+		hydratePasswords(this.settings, this.secretStore());
+	}
+
+	secretStore(): SecretStore | undefined {
+		// Undefined on Obsidian < 1.11.4, where passwords stay in plain text.
+		return (this.app as Partial<App>).secretStorage;
 	}
 
 	private async dataFileExists(): Promise<boolean> {
@@ -178,9 +186,13 @@ export default class CalDAVSyncPlugin extends Plugin {
 			new Notice('Settings failed to load at startup, so saving is disabled to protect your stored configuration. Restart Obsidian and try again.', 8000);
 			return;
 		}
-		await this.saveData(this.settings);
+		await this.persistSettings();
 		await this.initializeEngines();
 		this.autoSync?.start(this.settings.syncInterval);
+	}
+
+	private async persistSettings(): Promise<void> {
+		await this.saveData(externalizePasswords(this.settings, this.secretStore()));
 	}
 
 	private async initializeEngines(): Promise<void> {
@@ -337,6 +349,16 @@ class CalDAVSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
+			.setName('Store passwords in plain text')
+			.setDesc("Keep passwords inside the plugin's settings file instead of Obsidian's secret storage. Plain text travels with vault sync and backups; secret storage stays on this device, so each device asks for the password once.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.storePasswordsInPlainText ?? false)
+				.onChange(async (value) => {
+					this.plugin.settings.storePasswordsInPlainText = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
 			.setName('New tasks destination')
 			.setDesc('File where new calendar tasks will be added')
 			.addText(text => text
@@ -403,7 +425,8 @@ class CalDAVSettingTab extends PluginSettingTab {
 				.setButtonText('Remove')
 				.setWarning()
 				.onClick(async () => {
-					this.plugin.settings.calendars.splice(index, 1);
+					const [removed] = this.plugin.settings.calendars.splice(index, 1);
+					clearStoredPassword(removed, this.plugin.secretStore());
 					await this.plugin.saveSettings();
 					this.display();
 				}));

--- a/main.ts
+++ b/main.ts
@@ -172,7 +172,7 @@ export default class CalDAVSyncPlugin extends Plugin {
 
 	secretStore(): SecretStore | undefined {
 		// Undefined on Obsidian < 1.11.4, where passwords stay in plain text.
-		return (this.app as Partial<App>).secretStorage;
+		return (this.app as unknown as { secretStorage?: SecretStore }).secretStorage;
 	}
 
 	private async dataFileExists(): Promise<boolean> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tasks-caldav-sync",
-	"version": "1.3.0",
+	"version": "1.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tasks-caldav-sync",
-			"version": "1.3.0",
+			"version": "1.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"rrule": "^2.8.1"
@@ -27,7 +27,7 @@
 				"globals": "^14.0.0",
 				"jest": "^30.2.0",
 				"jiti": "^2.6.1",
-				"obsidian": "*",
+				"obsidian": "^1.12.3",
 				"obsidian-launcher": "^3.0.3",
 				"ts-jest": "^29.4.5",
 				"tslib": "2.4.0",
@@ -10764,9 +10764,9 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.10.2-1",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.10.2-1.tgz",
-			"integrity": "sha512-nScksVndWZDz0e/OAPa7Yo0aFaNuv6amyHg2L6MvlxfTJD6TfmkprVWhHjiVvUIGwcdvZRy6LGkn/v8D2E9jng==",
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10775,7 +10775,7 @@
 			},
 			"peerDependencies": {
 				"@codemirror/state": "6.5.0",
-				"@codemirror/view": "6.38.1"
+				"@codemirror/view": "6.38.6"
 			}
 		},
 		"node_modules/obsidian-launcher": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"globals": "^14.0.0",
 		"jest": "^30.2.0",
 		"jiti": "^2.6.1",
-		"obsidian": "latest",
+		"obsidian": "^1.12.3",
 		"obsidian-launcher": "^3.0.3",
 		"ts-jest": "^29.4.5",
 		"tslib": "2.4.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,12 @@ export interface CalendarMapping {
   serverUrl: string;
   username: string;
   password: string;
+  /**
+   * Id of this calendar's password in Obsidian's secret storage. When set, the
+   * persisted `password` is empty and the real value lives in secret storage;
+   * absent when the password is stored in plain text.
+   */
+  passwordSecretId?: string;
   /** Direction of sync for this calendar. Absent ⇒ 'bidirectional'. */
   syncDirection?: SyncDirection;
   /**
@@ -30,6 +36,12 @@ export interface CalDAVSettings {
   deleteBehavior: 'ask' | 'deleteCalDAV' | 'deleteObsidian' | 'keepBoth';
   includeObsidianLink: boolean;
   showAutoSyncNotifications: boolean;
+  /**
+   * Keep passwords inside data.json instead of Obsidian's secret storage.
+   * Absent ⇒ false. Plain text is also the fallback when the running Obsidian
+   * has no secret storage (added in 1.11.4).
+   */
+  storePasswordsInPlainText?: boolean;
   /**
    * Names of migrations that have already been applied to this vault. Used by
    * {@link runMigrations} to gate each migration to a single successful run,

--- a/src/utils/passwordStorage.test.ts
+++ b/src/utils/passwordStorage.test.ts
@@ -1,0 +1,151 @@
+import { CalDAVSettings, CalendarMapping, DEFAULT_CALDAV_SETTINGS } from '../types';
+import {
+  clearStoredPassword,
+  externalizePasswords,
+  hasPasswordsToExternalize,
+  hydratePasswords,
+  SecretStore,
+} from './passwordStorage';
+
+function fakeStore(): SecretStore & { secrets: Map<string, string> } {
+  const secrets = new Map<string, string>();
+  return {
+    secrets,
+    setSecret: (id, secret) => void secrets.set(id, secret),
+    getSecret: (id) => secrets.get(id) ?? null,
+  };
+}
+
+function calendar(overrides: Partial<CalendarMapping> = {}): CalendarMapping {
+  return {
+    obsidianTag: 'sync',
+    caldavCategory: 'sync',
+    calendarName: '',
+    serverUrl: '',
+    username: 'me',
+    password: 'hunter2',
+    calendarUrl: 'https://dav.example.com/cal/',
+    ...overrides,
+  };
+}
+
+function settings(overrides: Partial<CalDAVSettings> = {}): CalDAVSettings {
+  return { ...DEFAULT_CALDAV_SETTINGS, calendars: [calendar()], ...overrides };
+}
+
+describe('externalizePasswords', () => {
+  it('moves the password into secret storage and blanks the persisted copy', () => {
+    const store = fakeStore();
+    const live = settings();
+
+    const persisted = externalizePasswords(live, store);
+
+    const saved = persisted.calendars[0];
+    expect(saved.password).toBe('');
+    expect(saved.passwordSecretId).toMatch(/^caldav-sync-[0-9a-f-]+$/);
+    expect(store.getSecret(saved.passwordSecretId!)).toBe('hunter2');
+  });
+
+  it('keeps the live password intact and reuses the same secret id across saves', () => {
+    const store = fakeStore();
+    const live = settings();
+
+    const first = externalizePasswords(live, store);
+    const second = externalizePasswords(live, store);
+
+    expect(live.calendars[0].password).toBe('hunter2');
+    expect(second.calendars[0].passwordSecretId).toBe(first.calendars[0].passwordSecretId);
+    expect(store.secrets.size).toBe(1);
+  });
+
+  it('does not mint secrets for calendars without a password yet', () => {
+    const store = fakeStore();
+
+    const persisted = externalizePasswords(settings({ calendars: [calendar({ password: '' })] }), store);
+
+    expect(persisted.calendars[0].passwordSecretId).toBeUndefined();
+    expect(store.secrets.size).toBe(0);
+  });
+
+  it('persists plain text and clears the stored secret when plain text is chosen', () => {
+    const store = fakeStore();
+    store.setSecret('caldav-sync-old', 'hunter2');
+    const live = settings({
+      storePasswordsInPlainText: true,
+      calendars: [calendar({ passwordSecretId: 'caldav-sync-old' })],
+    });
+
+    const persisted = externalizePasswords(live, store);
+
+    expect(persisted.calendars[0].password).toBe('hunter2');
+    expect(persisted.calendars[0].passwordSecretId).toBeUndefined();
+    expect(store.getSecret('caldav-sync-old')).toBe('');
+  });
+
+  it('passes everything through untouched when secret storage is unavailable', () => {
+    const live = settings({ calendars: [calendar({ passwordSecretId: 'caldav-sync-old' })] });
+
+    expect(externalizePasswords(live, undefined)).toEqual(live);
+  });
+});
+
+describe('hydratePasswords', () => {
+  it('fills passwords from secret storage by id', () => {
+    const store = fakeStore();
+    store.setSecret('caldav-sync-a', 'hunter2');
+    const loaded = settings({ calendars: [calendar({ password: '', passwordSecretId: 'caldav-sync-a' })] });
+
+    hydratePasswords(loaded, store);
+
+    expect(loaded.calendars[0].password).toBe('hunter2');
+  });
+
+  it('leaves plain-text passwords untouched and missing secrets empty', () => {
+    const store = fakeStore();
+    const loaded = settings({
+      calendars: [
+        calendar({ password: 'plain' }),
+        calendar({ password: '', passwordSecretId: 'caldav-sync-gone' }),
+      ],
+    });
+
+    hydratePasswords(loaded, store);
+
+    expect(loaded.calendars[0].password).toBe('plain');
+    expect(loaded.calendars[1].password).toBe('');
+  });
+
+  it('round-trips a password through persist and reload', () => {
+    const store = fakeStore();
+    const persisted = JSON.parse(JSON.stringify(externalizePasswords(settings(), store))) as CalDAVSettings;
+
+    hydratePasswords(persisted, store);
+
+    expect(persisted.calendars[0].password).toBe('hunter2');
+  });
+});
+
+describe('hasPasswordsToExternalize', () => {
+  it('detects a plain-text password when secret storage is on', () => {
+    expect(hasPasswordsToExternalize(settings(), fakeStore())).toBe(true);
+  });
+
+  it('is false when opted out, already externalized, or without a store', () => {
+    expect(hasPasswordsToExternalize(settings({ storePasswordsInPlainText: true }), fakeStore())).toBe(false);
+    expect(hasPasswordsToExternalize(settings(), undefined)).toBe(false);
+    const externalized = settings({ calendars: [calendar({ password: '', passwordSecretId: 'caldav-sync-a' })] });
+    expect(hasPasswordsToExternalize(externalized, fakeStore())).toBe(false);
+  });
+});
+
+describe('clearStoredPassword', () => {
+  it('blanks the secret and drops the reference', () => {
+    const store = fakeStore();
+    store.setSecret('caldav-sync-a', 'hunter2');
+
+    const cleared = clearStoredPassword(calendar({ passwordSecretId: 'caldav-sync-a' }), store);
+
+    expect(cleared.passwordSecretId).toBeUndefined();
+    expect(store.getSecret('caldav-sync-a')).toBe('');
+  });
+});

--- a/src/utils/passwordStorage.ts
+++ b/src/utils/passwordStorage.ts
@@ -1,0 +1,60 @@
+import { CalDAVSettings, CalendarMapping } from '../types';
+
+/** The slice of Obsidian's `SecretStorage` (since 1.11.4) that passwords need. */
+export interface SecretStore {
+  setSecret(id: string, secret: string): void;
+  getSecret(id: string): string | null;
+}
+
+/**
+ * Fill in-memory passwords from secret storage. Plain-text entries pass
+ * through untouched; a missing secret leaves the password empty so the
+ * calendar reads as incomplete instead of syncing with a stale credential.
+ */
+export function hydratePasswords(settings: CalDAVSettings, store: SecretStore | undefined): void {
+  if (!store) return;
+  for (const calendar of settings.calendars) {
+    if (calendar.passwordSecretId && !calendar.password) {
+      calendar.password = store.getSecret(calendar.passwordSecretId) ?? '';
+    }
+  }
+}
+
+/** True when data.json holds a plain-text password that should move into secret storage. */
+export function hasPasswordsToExternalize(settings: CalDAVSettings, store: SecretStore | undefined): boolean {
+  if (!store || settings.storePasswordsInPlainText) return false;
+  return settings.calendars.some((calendar) => calendar.password !== '' && !calendar.passwordSecretId);
+}
+
+/**
+ * Shape settings for persistence. Each password moves into secret storage and
+ * is blanked in the returned copy, so data.json never holds credentials. When
+ * plain text is chosen it is persisted as-is and any stored secret is cleared;
+ * when secret storage is unavailable everything passes through untouched, so
+ * an Obsidian downgrade never drops the reference to an existing secret.
+ * Assigns missing secret ids on the live mapping so repeated saves reuse them.
+ */
+export function externalizePasswords(settings: CalDAVSettings, store: SecretStore | undefined): CalDAVSettings {
+  if (!store) return settings;
+  const calendars = settings.storePasswordsInPlainText
+    ? settings.calendars.map((calendar) => clearStoredPassword(calendar, store))
+    : settings.calendars.map((calendar) => moveToSecret(calendar, store));
+  return { ...settings, calendars };
+}
+
+/**
+ * Blank a calendar's stored secret and return a copy without the reference.
+ * Also used on calendar removal so credentials don't outlive the calendar.
+ */
+export function clearStoredPassword(calendar: CalendarMapping, store: SecretStore | undefined): CalendarMapping {
+  if (!store || !calendar.passwordSecretId) return calendar;
+  store.setSecret(calendar.passwordSecretId, '');
+  return { ...calendar, passwordSecretId: undefined };
+}
+
+function moveToSecret(calendar: CalendarMapping, store: SecretStore): CalendarMapping {
+  if (!calendar.password && !calendar.passwordSecretId) return calendar;
+  calendar.passwordSecretId ??= `caldav-sync-${crypto.randomUUID()}`;
+  store.setSecret(calendar.passwordSecretId, calendar.password);
+  return { ...calendar, password: '' };
+}


### PR DESCRIPTION
## Summary

CalDAV passwords no longer live in plain text in `data.json`. They are stored via Obsidian's [secret storage](https://docs.obsidian.md/plugins/guides/secret-storage) (`app.secretStorage`, Obsidian ≥ 1.11.4), with a per-vault opt-out toggle for plain text.

## How it works

The change sits at the single load/save choke point in `main.ts`; every consumer (sync engines, discoverer, browse modal, request dumper) keeps reading the in-memory `calendar.password` unchanged.

- **Save** — `externalizePasswords()` writes each password to secret storage under a stable per-calendar `passwordSecretId` and persists `data.json` with the password blanked.
- **Load** — `hydratePasswords()` fills passwords back in from secret storage.
- **Migration** — `safeLoad` detects a plain-text password on disk and re-persists once. Idempotent by state, so no migration file / `appliedMigrations` entry is needed.
- **Opt-out** — new "Store passwords in plain text" toggle (Behavior section, default off). Switching modes converts on the next save; flipping to plain text blanks the stored secret. Removing a calendar blanks its secret too.
- **Fallback** — Obsidian < 1.11.4 has no `app.secretStorage`; everything passes through as plain text without dropping an existing secret reference, so a downgrade never loses a password. `minAppVersion` stays unchanged.

Obsidian typings pinned to `^1.12.3`: the old lockfile resolution (1.10.2) predates the `SecretStorage` API, and 1.13 deprecates `display()`/`setWarning()`, which would fail lint on pre-existing code.

## Caveat

Secrets are vault-keyed **device-local** storage, so after syncing a vault to a new device the password must be entered once there. The setting description says as much. (This also composes nicely with any future per-device sync gating — see #46.)

## Testing

- `npm run build`, `npm run lint` clean
- `npm test` — 566 tests passing, coverage thresholds met; new unit tests for externalize/hydrate/opt-out/fallback round-trips in `src/utils/passwordStorage.test.ts`
- `npm run test:wdio` — 9/9 specs against real Obsidian 1.12.7, which has secret storage, so the specs exercised the externalize-on-save path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9jrk11yaotfiBWdRg7e8D