### PR TITLE
feat(sync): mobile support with a per-device sync switch (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Works with the [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian
 - **Recurrence** — `RRULE` round-trips between CalDAV and obsidian-tasks format
 - **Delete detection** — three-way diff detects deletions on either side
 - **Reconciliation** — automatically matches identical tasks when switching calendars or after lost sync data, preventing duplicates
+- **Mobile support** — runs on Obsidian mobile; a per-device switch decides which device talks to the server
 
 ## Requirements
 
-- Obsidian v0.15.0+
+- Obsidian v1.8.7+
 - [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) plugin (must be installed and enabled)
 - A CalDAV server with VTODO support
 
@@ -69,6 +70,7 @@ Global settings:
 
 | Setting | Description | Default |
 |---------|-------------|---------|
+| **Sync from this device** | Whether this device talks to the CalDAV server — see [Mobile and multiple devices](#mobile-and-multiple-devices) | on (desktop), off (mobile) |
 | **Sync interval** | Auto-sync period in minutes | `5` |
 | **New tasks destination** | File where incoming CalDAV tasks are created | `Inbox.md` |
 | **New tasks section** | Optional heading within the destination file | — |
@@ -84,6 +86,16 @@ Each calendar syncs in one of three directions:
 - **Push to server only** — Obsidian changes are sent to the server; server changes are never pulled back. A sync ID is still written into each task that is pushed, so it can be matched on later syncs.
 
 In one-way modes, deletions mirror in the sync direction only (a deletion on the source side propagates; a deletion on the target side is not sent back), and conflicts resolve automatically toward the source side.
+
+### Mobile and multiple devices
+
+The plugin runs on Obsidian mobile, but only one device should talk to the CalDAV server: if several devices sync the same calendars, they race each other's sync state and can duplicate tasks.
+
+The **Sync from this device** switch controls this per device. It is stored on the device itself — not in the vault — so it does not travel with your settings:
+
+- Defaults to **on** for desktop and **off** for mobile.
+- Leave it on for exactly one device. Every other device still receives synced tasks through your regular vault sync (Obsidian Sync, Syncthing, etc.).
+- To sync from your phone instead, turn the switch off on the desktop and on on the phone.
 
 ### Conflict resolution
 

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Editor, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import { App, Editor, Notice, Platform, Plugin, PluginSettingTab, Setting } from 'obsidian';
 import { CalDAVSettings, CalendarMapping, SyncDirection } from './src/types';
 import { describeIncompleteCalendar } from './src/utils/calendarConfig';
 import { calendarLabel } from './src/utils/calendarLabel';
@@ -167,6 +167,21 @@ export default class CalDAVSyncPlugin extends Plugin {
 		});
 	}
 
+	/**
+	 * Whether this device talks to the CalDAV server. Stored per device (vault
+	 * localStorage, never in data.json) so exactly one device can own syncing
+	 * while the vault — settings, baseline, id mapping — syncs everywhere.
+	 * Defaults to on for desktop and off for mobile.
+	 */
+	syncsOnThisDevice(): boolean {
+		const stored: unknown = this.app.loadLocalStorage('tasks-caldav-sync:sync-on-this-device');
+		return typeof stored === 'boolean' ? stored : !Platform.isMobile;
+	}
+
+	setSyncsOnThisDevice(value: boolean): void {
+		this.app.saveLocalStorage('tasks-caldav-sync:sync-on-this-device', value);
+	}
+
 	private async dataFileExists(): Promise<boolean> {
 		const dir = this.manifest.dir;
 		if (!dir) return false;
@@ -257,6 +272,7 @@ export default class CalDAVSyncPlugin extends Plugin {
 	}
 
 	private async syncAll(): Promise<void> {
+		if (!this.syncsOnThisDevice()) return;
 		// A tick that lands mid-sync skips silently; the next one catches up.
 		await this.runSync(async () => {
 			for (const engine of this.syncEngines) {
@@ -267,6 +283,10 @@ export default class CalDAVSyncPlugin extends Plugin {
 	}
 
 	private async syncAllEngines(dryRun: boolean): Promise<SyncResult[] | null> {
+		if (!this.syncsOnThisDevice()) {
+			new Notice('Syncing is off on this device — turn on sync from this device in the plugin settings.');
+			return null;
+		}
 		const results = await this.runSync(async () => {
 			const out: SyncResult[] = [];
 			for (const engine of this.syncEngines) {
@@ -321,6 +341,13 @@ class CalDAVSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName('Behavior')
 			.setHeading();
+
+		new Setting(containerEl)
+			.setName('Sync from this device')
+			.setDesc('Per-device switch, not synced with your vault. Leave it on for exactly one device so several devices never sync the same calendars over each other. Off by default on mobile.')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.syncsOnThisDevice())
+				.onChange((value) => this.plugin.setSyncsOnThisDevice(value)));
 
 		new Setting(containerEl)
 			.setName('Sync interval')

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
 	"id": "tasks-caldav-sync",
 	"name": "Tasks CalDAV Sync",
 	"version": "1.5.0",
-	"minAppVersion": "0.15.0",
+	"minAppVersion": "1.8.7",
 	"description": "Bidirectional sync between tasks and CalDAV servers.",
 	"author": "José Coelho",
 	"authorUrl": "https://github.com/josecoelho",
-	"isDesktopOnly": true
+	"isDesktopOnly": false
 }


### PR DESCRIPTION
## Summary

Enables the plugin on mobile (closes #46) and adds a per-device **"Sync from this device"** switch so only one device talks to the CalDAV server — several devices syncing the same calendars would race each other's baseline (`.caldav-sync/` travels with the vault) and duplicate tasks.

## How it works

- The switch is stored in vault-keyed **device-local** storage (`app.saveLocalStorage`/`loadLocalStorage`), never in `data.json` — so it doesn't travel with vault sync, and each device decides for itself.
- Defaults: **on for desktop, off for mobile** (`Platform.isMobile`), preserving today's behavior for existing installs.
- Gating sits at the two sync entry points: auto-sync ticks skip silently on a disabled device; the manual sync/dry-run commands show a notice explaining how to enable. Settings stay fully editable everywhere.
- Engine initialization is local-only (tasks-plugin check + storage files), so a disabled device never touches the network.
- This covers all three setups: one designated sync device, mobile installed but passive, or mobile-only sync (switch off on desktop, on on the phone).

## Mobile enablement

- `manifest.json`: `isDesktopOnly: false`; `minAppVersion` bumps to `1.8.7`, where `loadLocalStorage`/`saveLocalStorage` entered the public API.
- The runtime was already mobile-safe: all HTTP goes through Obsidian's `requestUrl`, and nothing in `src/` imports Node or Electron.
- README gains a "Mobile and multiple devices" section and the new setting in the global-settings table.

## Testing

- `npm run build`, `npm run lint` clean; `npm test` — 555 tests passing, thresholds met
- `npm run test:wdio` — 9/9 specs against real Obsidian 1.12.7. The specs sync on desktop where the switch defaults to on, so they double as the regression check for the gate: a broken/inverted gate fails every spec.
- Not yet verified on a real mobile device — the #46 reporter ran an `isDesktopOnly`-flipped build on Android without crashes and volunteered to test; this PR is the candidate for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9jrk11yaotfiBWdRg7e8D