### PR TITLE
fix(caldav): parse calendar-data with inline xmlns (Open-Xchange / mailbox.org)

### DIFF
--- a/src/caldav/calDAVClientDirect.test.ts
+++ b/src/caldav/calDAVClientDirect.test.ts
@@ -221,6 +221,18 @@ END:VCALENDAR</c:calendar-data>
             expect(vtodos[0].data).toContain('todo-1');
             expect(vtodos[1].data).toContain('todo-2');
         });
+
+        it('should parse calendar-data with inline xmlns attribute (Open-Xchange format)', () => {
+            const response = `<?xml version="1.0" encoding="UTF-8"?>\r\n<D:multistatus xmlns:D="DAV:" xmlns:CAL="urn:ietf:params:xml:ns:caldav">\r\n  <D:response>\r\n    <D:href>/caldav/user123/todo-ox-1.ics</D:href>\r\n    <D:propstat>\r\n      <D:prop>\r\n        <D:getetag>etag-ox-1</D:getetag>\r\n        <calendar-data xmlns="urn:ietf:params:xml:ns:caldav"><![CDATA[BEGIN:VCALENDAR\nPRODID:Open-Xchange\nBEGIN:VTODO\nUID:todo-ox-1\nSUMMARY:Test task\nSTATUS:IN-PROCESS\nEND:VTODO\nEND:VCALENDAR]]></calendar-data>\r\n      </D:prop>\r\n      <D:status>HTTP/1.1 200 OK</D:status>\r\n    </D:propstat>\r\n  </D:response>\r\n</D:multistatus>`;
+
+            const vtodos = CalDAVClientDirect.parseVTODOsFromXML(response, 'https://dav.mailbox.org');
+
+            expect(vtodos).toHaveLength(1);
+            expect(vtodos[0].url).toBe('https://dav.mailbox.org/caldav/user123/todo-ox-1.ics');
+            expect(vtodos[0].data).toContain('UID:todo-ox-1');
+            expect(vtodos[0].data).toContain('STATUS:IN-PROCESS');
+            expect(vtodos[0].etag).toBe('etag-ox-1');
+        });
     });
 
     describe('connect() and pinned fetch', () => {

--- a/src/caldav/calDAVClientDirect.ts
+++ b/src/caldav/calDAVClientDirect.ts
@@ -128,7 +128,7 @@ export class CalDAVClientDirect implements CalDAVClient {
         : undefined;
 
       // Extract calendar data (VTODO) — handle optional CDATA wrapping, any namespace prefix
-      const dataMatch = responseBlock.match(/<(?:\w+:)?calendar-data>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/(?:\w+:)?calendar-data>/);
+      const dataMatch = responseBlock.match(/<(?:\w+:)?calendar-data(?:\s[^>]*)?>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/(?:\w+:)?calendar-data>/);
       if (!dataMatch) continue;
 
       const data = decodeXMLEntities(dataMatch[1].trim());


### PR DESCRIPTION
## Problem

Open-Xchange (used by mailbox.org and others) emits `<calendar-data>` with an inline namespace declaration:

```xml
<calendar-data xmlns="urn:ietf:params:xml:ns:caldav"><![CDATA[BEGIN:VCALENDAR...]]></calendar-data>
```

The previous regex matched `<calendar-data>` or `<ns:calendar-data>` but not a tag with attributes, so every VTODO was silently dropped. Sync always showed **Calendar tasks (0)** for all mailbox.org users regardless of how many tasks existed.

## Fix

Allow optional attributes on the opening tag:

```diff
- /<(?:\w+:)?calendar-data>(?:<!\[CDATA\[)?...
+ /<(?:\w+:)?calendar-data(?:\s[^>]*)?>(?:<!\[CDATA\[)?...
```

## Test

Added a unit test that uses the exact XML shape Open-Xchange / mailbox.org returns, including the `xmlns` attribute and CDATA wrapping.

Verified against a live mailbox.org CalDAV account — sync now correctly fetches tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)