### PR TITLE
fix(caldav): strip VTODO sub-components before extracting task properties

### DIFF
--- a/src/caldav/vtodoMapper.test.ts
+++ b/src/caldav/vtodoMapper.test.ts
@@ -723,6 +723,24 @@ END:VTODO`;
       expect(task.title).toBe('follow up on https://aurl.com');
     });
 
+    it('should not bleed VALARM DESCRIPTION into task body', () => {
+      const vtodoData = `BEGIN:VTODO\r\nUID:valarm-test\r\nSUMMARY:My task\r\nSTATUS:NEEDS-ACTION\r\nBEGIN:VALARM\r\nTRIGGER:-PT15M\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder text\r\nEND:VALARM\r\nEND:VTODO`;
+
+      const vtodo: CalendarObject = { data: vtodoData, etag: 'etag-1', url: 'http://example.com/test.ics' };
+      const task = mapper.vtodoToTask(vtodo);
+
+      expect(task.body).toBe('');
+    });
+
+    it('should read VTODO DESCRIPTION when VALARM is also present', () => {
+      const vtodoData = `BEGIN:VTODO\r\nUID:valarm-with-desc\r\nSUMMARY:My task\r\nDESCRIPTION:My notes\r\nSTATUS:NEEDS-ACTION\r\nBEGIN:VALARM\r\nTRIGGER:-PT15M\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder text\r\nEND:VALARM\r\nEND:VTODO`;
+
+      const vtodo: CalendarObject = { data: vtodoData, etag: 'etag-1', url: 'http://example.com/test.ics' };
+      const task = mapper.vtodoToTask(vtodo);
+
+      expect(task.body).toBe('My notes');
+    });
+
     it('should handle folded DESCRIPTION lines', () => {
       const vtodoData = `BEGIN:VTODO\r\nUID:folded-desc\r\nSUMMARY:Task\r\nDESCRIPTION:A very long description that has been \r\n folded by the server into multiple lines\r\nSTATUS:NEEDS-ACTION\r\nEND:VTODO`;
 

--- a/src/caldav/vtodoMapper.ts
+++ b/src/caldav/vtodoMapper.ts
@@ -92,9 +92,12 @@ export class VTODOMapper {
    */
   vtodoToTask(vtodo: CalendarObject): VTODOTaskFields {
     const unfolded = this.unfold(vtodo.data);
-    // Extract only the VTODO section to avoid matching properties from VTIMEZONE or other components
+    // Extract only the VTODO section to avoid matching properties from VTIMEZONE or other components,
+    // then strip sub-components (VALARM etc.) so their properties don't bleed into task fields
+    // — a sub-component's DESCRIPTION is not the task's description.
     const vtodoMatch = unfolded.match(/BEGIN:VTODO[\s\S]*?END:VTODO/);
-    const data = vtodoMatch ? vtodoMatch[0] : unfolded;
+    const data = (vtodoMatch ? vtodoMatch[0] : unfolded)
+      .replace(/BEGIN:(?!VTODO\b)\w+[\s\S]*?END:\w+(\r?\n|$)/g, '');
 
     // Inline #tags in SUMMARY (written by older plugin versions or other
     // clients) move into tags[], so corrupted tasks heal instead of gaining


### PR DESCRIPTION
## Problem

`extractRawProperty` searched the full `BEGIN:VTODO…END:VTODO` block including nested sub-components (VALARM, etc.). A `DESCRIPTION` property inside a `VALARM` was matched and treated as the task's own description, producing a spurious indented line in Obsidian.

RFC 5545 requires `ACTION:DISPLAY` alarms to carry a `DESCRIPTION` (the notification popup text). Several CalDAV servers set this to their product name, so every task with a reminder appeared with an unexpected sub-item in Obsidian.

## Fix

After extracting the VTODO block, strip any sub-components before passing the data to property extractors:

```diff
  const vtodoMatch = unfolded.match(/BEGIN:VTODO[\s\S]*?END:VTODO/);
- const data = vtodoMatch ? vtodoMatch[0] : unfolded;
+ const data = (vtodoMatch ? vtodoMatch[0] : unfolded)
+   .replace(/BEGIN:(?!VTODO\b)\w+[\s\S]*?END:\w+(\r?\n|$)/g, '');
```

Only top-level VTODO properties are now visible to the field parsers.

## Tests

- VALARM `DESCRIPTION` no longer bleeds into task body
- VTODO `DESCRIPTION` still parsed correctly when a VALARM is also present

🤖 Generated with [Claude Code](https://claude.com/claude-code)