### PR TITLE
feat(caldav): jtx Board compatibility (foreign properties + STATUS:IN-PROCESS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ If your server tasks have no matching `CATEGORIES` (for example, tasks created f
 | Vikunja | Automated E2E suite |
 | Baïkal (SabreDAV) | Automated E2E suite |
 | Fastmail | Manually verified |
+| mailbox.org (Open-Xchange) | Manually verified |
+| jtx Board (Android) | Manually verified |
 
 Should work with any CalDAV server that supports VTODO, such as Synology.
 

--- a/src/caldav/vtodoMapper.test.ts
+++ b/src/caldav/vtodoMapper.test.ts
@@ -320,7 +320,7 @@ END:VTODO`;
     it('should map all VTODO statuses correctly', () => {
       const statuses = [
         { vtodo: 'NEEDS-ACTION', obsidian: 'TODO' },
-        { vtodo: 'IN-PROCESS', obsidian: 'IN_PROGRESS' },
+        { vtodo: 'IN-PROCESS', obsidian: 'TODO' }, // IN-PROCESS maps to TODO — no Obsidian equivalent
         { vtodo: 'COMPLETED', obsidian: 'DONE' },
         { vtodo: 'CANCELLED', obsidian: 'CANCELLED' }
       ];
@@ -1353,6 +1353,207 @@ END:VTODO`;
       expect((md.match(/#chores\/garden/g) || []).length).toBe(1);
       expect(md).toContain('water the plants');
       expect(md).not.toContain('plants #sync #');
+    });
+  });
+
+  describe('merge mode — existingData preserves foreign properties', () => {
+    const baseTask: Omit<CommonTask, 'uid'> = {
+      title: 'Updated task',
+      status: 'TODO',
+      dueDate: null,
+      scheduledDate: null,
+      startDate: null,
+      completedDate: null,
+      priority: 'none',
+      recurrenceRule: '',
+      tags: [],
+      body: '',
+    };
+
+    function existingVTODO(extraLines: string[]): string {
+      return [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//jtx Board//EN',
+        'BEGIN:VTODO',
+        'UID:existing-uid-123',
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:Original title',
+        'STATUS:NEEDS-ACTION',
+        ...extraLines,
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+    }
+
+    it('updates managed SUMMARY and STATUS on merge', () => {
+      const result = mapper.taskToVTODO({ ...baseTask, title: 'New title', status: 'IN_PROGRESS' }, 'existing-uid-123', existingVTODO([]));
+      expect(result).toContain('SUMMARY:New title');
+      expect(result).toContain('STATUS:IN-PROCESS');
+      expect(result).not.toContain('SUMMARY:Original title');
+    });
+
+    it('preserves UID from existing data exactly once', () => {
+      const result = mapper.taskToVTODO(baseTask, 'existing-uid-123', existingVTODO([]));
+      expect(result).toContain('UID:existing-uid-123');
+      expect((result.match(/^UID:/gm) ?? []).length).toBe(1);
+    });
+
+    it('preserves RELATED-TO through update', () => {
+      const result = mapper.taskToVTODO(baseTask, 'existing-uid-123', existingVTODO(['RELATED-TO;RELTYPE=PARENT:parent-uid-xyz']));
+      expect(result).toContain('RELATED-TO;RELTYPE=PARENT:parent-uid-xyz');
+    });
+
+    it('preserves X- extension properties through update', () => {
+      const result = mapper.taskToVTODO(baseTask, 'existing-uid-123', existingVTODO([
+        'X-JTX-FOOBAR:custom-metadata',
+        'X-APPLE-SORT-ORDER:1',
+      ]));
+      expect(result).toContain('X-JTX-FOOBAR:custom-metadata');
+      expect(result).toContain('X-APPLE-SORT-ORDER:1');
+    });
+
+    it('preserves VALARM sub-component through update', () => {
+      const result = mapper.taskToVTODO(baseTask, 'existing-uid-123', existingVTODO([
+        'BEGIN:VALARM',
+        'ACTION:DISPLAY',
+        'DESCRIPTION:Reminder',
+        'TRIGGER:-PT15M',
+        'END:VALARM',
+      ]));
+      expect(result).toContain('BEGIN:VALARM');
+      expect(result).toContain('ACTION:DISPLAY');
+      expect(result).toContain('TRIGGER:-PT15M');
+      expect(result).toContain('END:VALARM');
+    });
+
+    it('preserves PERCENT-COMPLETE when task is not completing', () => {
+      const result = mapper.taskToVTODO(baseTask, 'existing-uid-123', existingVTODO(['PERCENT-COMPLETE:40']));
+      expect(result).toContain('PERCENT-COMPLETE:40');
+    });
+
+    it('strips old PERCENT-COMPLETE and sets 100 when completing', () => {
+      const completing = { ...baseTask, status: 'DONE' as const, completedDate: '2026-07-18' };
+      const result = mapper.taskToVTODO(completing, 'existing-uid-123', existingVTODO(['PERCENT-COMPLETE:40']));
+      expect(result).toContain('PERCENT-COMPLETE:100');
+      expect(result).not.toContain('PERCENT-COMPLETE:40');
+    });
+
+    it('strips COMPLETED from server when task is not completed', () => {
+      const result = mapper.taskToVTODO(baseTask, 'existing-uid-123', existingVTODO(['COMPLETED:20260101T120000Z']));
+      expect(result).not.toContain('COMPLETED:');
+    });
+
+    it('replaces DUE when task has a new due date', () => {
+      const result = mapper.taskToVTODO({ ...baseTask, dueDate: '2026-08-15' }, 'existing-uid-123', existingVTODO(['DUE;VALUE=DATE:20250101']));
+      expect(result).toContain('DUE;VALUE=DATE:20260815');
+      expect(result).not.toContain('DUE;VALUE=DATE:20250101');
+    });
+
+    it('strips DUE when task has no due date', () => {
+      const result = mapper.taskToVTODO(baseTask, 'existing-uid-123', existingVTODO(['DUE;VALUE=DATE:20250101']));
+      expect(result).not.toMatch(/^DUE/m);
+    });
+
+    it('preserves VTIMEZONE block from existing data', () => {
+      const withTimezone = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//Test//EN',
+        'BEGIN:VTIMEZONE',
+        'TZID:America/New_York',
+        'BEGIN:STANDARD',
+        'DTSTART:19701101T020000',
+        'END:STANDARD',
+        'END:VTIMEZONE',
+        'BEGIN:VTODO',
+        'UID:tz-uid',
+        'SUMMARY:Original',
+        'STATUS:NEEDS-ACTION',
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      const result = mapper.taskToVTODO(baseTask, 'tz-uid', withTimezone);
+      expect(result).toContain('BEGIN:VTIMEZONE');
+      expect(result).toContain('TZID:America/New_York');
+      expect(result).toContain('END:VTIMEZONE');
+    });
+
+    it('falls back to fresh build when existingData is absent', () => {
+      const result = mapper.taskToVTODO({ ...baseTask, title: 'My task' }, 'fresh-uid');
+      expect(result).toContain('BEGIN:VCALENDAR');
+      expect(result).toContain('UID:fresh-uid');
+      expect(result).toContain('SUMMARY:My task');
+    });
+
+    describe('STATUS:IN-PROCESS preservation', () => {
+      it('preserves STATUS:IN-PROCESS when Obsidian edits title (task stays TODO)', () => {
+        const existing = existingVTODO(['STATUS:IN-PROCESS'].concat(
+          existingVTODO([]).includes('STATUS:NEEDS-ACTION') ? [] : [],
+        )).replace('STATUS:NEEDS-ACTION', 'STATUS:IN-PROCESS');
+        const result = mapper.taskToVTODO({ ...baseTask, title: 'Edited title' }, 'existing-uid-123', existing);
+        expect(result).toContain('STATUS:IN-PROCESS');
+        expect(result).not.toContain('STATUS:NEEDS-ACTION');
+      });
+
+      it('overrides STATUS:IN-PROCESS with COMPLETED when completing', () => {
+        const existing = existingVTODO([]).replace('STATUS:NEEDS-ACTION', 'STATUS:IN-PROCESS');
+        const completing = { ...baseTask, status: 'DONE' as const, completedDate: '2026-07-19' };
+        const result = mapper.taskToVTODO(completing, 'existing-uid-123', existing);
+        expect(result).toContain('STATUS:COMPLETED');
+        expect(result).not.toContain('STATUS:IN-PROCESS');
+      });
+
+      it('overrides STATUS:IN-PROCESS with CANCELLED when cancelling', () => {
+        const existing = existingVTODO([]).replace('STATUS:NEEDS-ACTION', 'STATUS:IN-PROCESS');
+        const result = mapper.taskToVTODO({ ...baseTask, status: 'CANCELLED' }, 'existing-uid-123', existing);
+        expect(result).toContain('STATUS:CANCELLED');
+        expect(result).not.toContain('STATUS:IN-PROCESS');
+      });
+
+      it('passes STATUS:NEEDS-ACTION through when task is TODO', () => {
+        const result = mapper.taskToVTODO(baseTask, 'existing-uid-123', existingVTODO([]));
+        expect(result).toContain('STATUS:NEEDS-ACTION');
+      });
+    });
+
+    describe('datetime precision on DUE and DTSTART', () => {
+      it('preserves TZID and time-of-day when updating DUE date', () => {
+        const existing = existingVTODO(['DUE;TZID=Europe/Berlin:20240115T140000']);
+        const result = mapper.taskToVTODO({ ...baseTask, dueDate: '2026-08-20' }, 'existing-uid-123', existing);
+        expect(result).toContain('DUE;TZID=Europe/Berlin:20260820T140000');
+        expect(result).not.toMatch(/DUE;VALUE=DATE/);
+      });
+
+      it('preserves UTC Z suffix when updating DUE date', () => {
+        const existing = existingVTODO(['DUE:20240115T140000Z']);
+        const result = mapper.taskToVTODO({ ...baseTask, dueDate: '2026-08-20' }, 'existing-uid-123', existing);
+        expect(result).toContain('DUE:20260820T140000Z');
+      });
+
+      it('preserves TZID and time-of-day when updating DTSTART date', () => {
+        const existing = existingVTODO(['DTSTART;TZID=America/New_York:20240110T090000']);
+        const result = mapper.taskToVTODO({ ...baseTask, scheduledDate: '2026-09-01' }, 'existing-uid-123', existing);
+        expect(result).toContain('DTSTART;TZID=America/New_York:20260901T090000');
+      });
+
+      it('keeps DUE as VALUE=DATE when existing was date-only', () => {
+        const existing = existingVTODO(['DUE;VALUE=DATE:20240115']);
+        const result = mapper.taskToVTODO({ ...baseTask, dueDate: '2026-08-20' }, 'existing-uid-123', existing);
+        expect(result).toContain('DUE;VALUE=DATE:20260820');
+      });
+
+      it('writes VALUE=DATE when DUE was not previously set', () => {
+        const result = mapper.taskToVTODO({ ...baseTask, dueDate: '2026-08-20' }, 'existing-uid-123', existingVTODO([]));
+        expect(result).toContain('DUE;VALUE=DATE:20260820');
+      });
+
+      it('preserves same datetime unchanged when due date is not modified', () => {
+        const existing = existingVTODO(['DUE;TZID=Europe/Berlin:20240115T140000']);
+        const result = mapper.taskToVTODO({ ...baseTask, dueDate: '2024-01-15' }, 'existing-uid-123', existing);
+        expect(result).toContain('DUE;TZID=Europe/Berlin:20240115T140000');
+      });
     });
   });
 

--- a/src/caldav/vtodoMapper.ts
+++ b/src/caldav/vtodoMapper.ts
@@ -19,18 +19,51 @@ type VTODOTaskFields = Omit<CommonTask, 'uid'>;
 export class VTODOMapper {
   /**
    * Convert a CommonTask to VTODO iCalendar string.
-   * @param task The common task
-   * @param uid The CalDAV UID (use for updates, generate new for creates)
-   * @returns VTODO iCalendar string
+   *
+   * When `existingData` is supplied (update/complete paths), only the
+   * properties this plugin manages are replaced; all other properties
+   * (RELATED-TO, VALARM blocks, X-* extension lines, PERCENT-COMPLETE
+   * when not completing, etc.) are carried through unchanged. This
+   * preserves data written by other CalDAV clients such as jtx Board.
+   *
+   * When `existingData` is absent (create path), a fresh VCALENDAR is built.
    */
-  taskToVTODO(task: Omit<CommonTask, 'uid'>, uid: string): string {
-    const lines: string[] = [];
+  taskToVTODO(task: Omit<CommonTask, 'uid'>, uid: string, existingData?: string): string {
+    return existingData
+      ? this.mergeIntoVTODO(task, existingData)
+      : this.buildFreshVTODO(task, uid);
+  }
 
-    lines.push('BEGIN:VCALENDAR');
-    lines.push('VERSION:2.0');
-    lines.push('PRODID:-//Obsidian//Tasks CalDAV Sync//EN');
-    lines.push('BEGIN:VTODO');
-    lines.push(`UID:${uid}`);
+  private buildFreshVTODO(task: Omit<CommonTask, 'uid'>, uid: string): string {
+    return [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//Obsidian//Tasks CalDAV Sync//EN',
+      'BEGIN:VTODO',
+      `UID:${uid}`,
+      ...this.buildManagedLines(task),
+      'END:VTODO',
+      'END:VCALENDAR',
+    ].join('\r\n');
+  }
+
+  /**
+   * The VTODO properties owned by this plugin. Written on every create/update.
+   * Any property NOT in this list is foreign and must pass through untouched
+   * in merge mode.
+   *
+   * When `mergeContext` is provided we are on the update/complete path:
+   *  - STATUS is omitted for TODO tasks so the server's IN-PROCESS (or
+   *    NEEDS-ACTION) passes through untouched from the merge loop.
+   *  - DUE/DTSTART carry the existing timezone and time-of-day when the
+   *    server stored a datetime value, so jtx Board's time precision survives
+   *    an Obsidian title or date change.
+   */
+  private buildManagedLines(
+    task: Omit<CommonTask, 'uid'>,
+    mergeContext?: { existingDue?: string | null; existingDtstart?: string | null },
+  ): string[] {
+    const lines: string[] = [];
     lines.push(`DTSTAMP:${this.formatDateTimeUTC(new Date())}`);
     lines.push(`LAST-MODIFIED:${this.formatDateTimeUTC(new Date())}`);
     lines.push(`SUMMARY:${this.escapeText(task.title)}`);
@@ -47,18 +80,30 @@ export class VTODOMapper {
       lines.push(`URL:${task.obsidianUrl}`);
     }
 
-    // Status mapping
-    lines.push(`STATUS:${this.mapStatusToVTODO(task.status)}`);
+    // Status mapping. In merge mode, STATUS for open (TODO) tasks is preserved
+    // from the existing VTODO by the merge loop — emitting it here would
+    // overwrite IN-PROCESS.
+    if (!mergeContext || task.status !== 'TODO') {
+      lines.push(`STATUS:${this.mapStatusToVTODO(task.status)}`);
+    }
 
     // Due date
     if (task.dueDate) {
-      lines.push(`DUE;VALUE=DATE:${this.formatDate(task.dueDate)}`);
+      lines.push(
+        mergeContext?.existingDue
+          ? this.mergeDatetime('DUE', task.dueDate, mergeContext.existingDue)
+          : `DUE;VALUE=DATE:${this.formatDate(task.dueDate)}`,
+      );
     }
 
     // DTSTART carries the scheduled date (⏳) — the field CalDAV clients plan
     // by. The start date (🛫) has no CalDAV counterpart and never syncs.
     if (task.scheduledDate) {
-      lines.push(`DTSTART;VALUE=DATE:${this.formatDate(task.scheduledDate)}`);
+      lines.push(
+        mergeContext?.existingDtstart
+          ? this.mergeDatetime('DTSTART', task.scheduledDate, mergeContext.existingDtstart)
+          : `DTSTART;VALUE=DATE:${this.formatDate(task.scheduledDate)}`,
+      );
     }
 
     // Completed date
@@ -80,10 +125,71 @@ export class VTODOMapper {
       lines.push(`CATEGORIES:${task.tags.map(t => this.escapeText(t)).join(',')}`);
     }
 
-    lines.push('END:VTODO');
-    lines.push('END:VCALENDAR');
+    return lines;
+  }
 
-    return lines.join('\r\n');
+  /**
+   * Patch an existing iCalendar string in place. Strips only the properties
+   * this plugin owns, then injects fresh values before END:VTODO. Sub-components
+   * (VALARM, etc.) and unrecognised properties pass through verbatim.
+   *
+   * PERCENT-COMPLETE is treated specially: it is only stripped (and re-emitted
+   * as 100) when the task is being completed. Otherwise the server's value
+   * (e.g. jtx Board's in-progress percentage) is preserved.
+   */
+  private mergeIntoVTODO(task: Omit<CommonTask, 'uid'>, existingData: string): string {
+    const ALWAYS_MANAGED = new Set([
+      'SUMMARY', 'DESCRIPTION', 'DUE', 'DTSTART',
+      'PRIORITY', 'RRULE', 'CATEGORIES', 'DTSTAMP', 'LAST-MODIFIED', 'COMPLETED', 'URL',
+      // STATUS and PERCENT-COMPLETE are handled inline below
+    ]);
+    const isCompleting = !!task.completedDate;
+
+    const unfolded = this.unfold(existingData);
+    const mergeContext = {
+      existingDue: this.extractRawDatetimeLine(unfolded, 'DUE'),
+      existingDtstart: this.extractRawDatetimeLine(unfolded, 'DTSTART'),
+    };
+
+    const lines = unfolded.split(/\r?\n/).filter(l => l.length > 0);
+    const out: string[] = [];
+    let inVTODO = false;
+    let depth = 0;
+
+    for (const line of lines) {
+      if (!inVTODO) {
+        out.push(line);
+        if (line === 'BEGIN:VTODO') inVTODO = true;
+        continue;
+      }
+
+      if (line === 'END:VTODO') {
+        out.push(...this.buildManagedLines(task, mergeContext));
+        out.push(line);
+        inVTODO = false;
+        continue;
+      }
+
+      if (line.startsWith('BEGIN:')) { depth++; out.push(line); continue; }
+      if (line.startsWith('END:')) { depth--; out.push(line); continue; }
+      if (depth > 0) { out.push(line); continue; }
+
+      const propName = line.split(/[;:]/)[0].toUpperCase();
+      if (ALWAYS_MANAGED.has(propName)) continue;
+      if (propName === 'PERCENT-COMPLETE' && isCompleting) continue;
+
+      // STATUS: preserve the server's value (IN-PROCESS or NEEDS-ACTION) when
+      // Obsidian has no opinion — i.e. the task is open (TODO). Terminal states
+      // (DONE, CANCELLED) are stripped here and re-emitted by buildManagedLines.
+      if (propName === 'STATUS') {
+        if (task.status === 'TODO') out.push(line);
+        continue;
+      }
+
+      out.push(line);
+    }
+
+    return out.join('\r\n');
   }
 
   /**
@@ -170,7 +276,10 @@ export class VTODOMapper {
       case 'NEEDS-ACTION':
         return 'TODO';
       case 'IN-PROCESS':
-        return 'IN_PROGRESS';
+        // Obsidian-tasks has no in-progress checkbox; treat as open so the diff
+        // sees TODO on both sides and doesn't generate a spurious update that
+        // would overwrite IN-PROCESS with NEEDS-ACTION on every sync.
+        return 'TODO';
       case 'COMPLETED':
         return 'DONE';
       case 'CANCELLED':
@@ -212,6 +321,34 @@ export class VTODOMapper {
     if (priority <= 6) return 'medium';
     if (priority <= 8) return 'low';
     return 'lowest';
+  }
+
+  /**
+   * Extract the raw params+value segment of a date/datetime property line so
+   * the merge path can preserve time precision and timezone.
+   * Returns e.g. `;TZID=Europe/Berlin:20240115T140000` or `;VALUE=DATE:20240115`.
+   */
+  private extractRawDatetimeLine(unfolded: string, property: string): string | null {
+    const regex = new RegExp(`^${property}(;[^:]+)?:(.+)$`, 'm');
+    const match = unfolded.match(regex);
+    if (!match) return null;
+    return `${match[1] ?? ''}:${match[2].trim()}`;
+  }
+
+  /**
+   * Emit a DUE or DTSTART line that preserves the server's timezone and
+   * time-of-day when it stored a datetime value, updating only the date digits.
+   * Falls back to VALUE=DATE when the existing value was date-only.
+   */
+  private mergeDatetime(prop: string, newDate: string, existingParamsAndValue: string): string {
+    const colonIdx = existingParamsAndValue.indexOf(':');
+    const params = colonIdx >= 0 ? existingParamsAndValue.substring(0, colonIdx) : '';
+    const value = colonIdx >= 0 ? existingParamsAndValue.substring(colonIdx + 1) : existingParamsAndValue;
+    if (value.length > 8 && value.includes('T')) {
+      // Datetime: update the 8-digit date prefix, carry the time suffix (T…Z or T…)
+      return `${prop}${params}:${this.formatDate(newDate)}${value.substring(8)}`;
+    }
+    return `${prop};VALUE=DATE:${this.formatDate(newDate)}`;
   }
 
   /**

--- a/src/sync/caldavAdapter.test.ts
+++ b/src/sync/caldavAdapter.test.ts
@@ -74,7 +74,7 @@ describe('CalDAVAdapter', () => {
       expect(adapter.toCommonTask(done, 'id').status).toBe('DONE');
 
       const inProgress = makeCalObj('c-ip', 'In progress', ['STATUS:IN-PROCESS']);
-      expect(adapter.toCommonTask(inProgress, 'id').status).toBe('IN_PROGRESS');
+      expect(adapter.toCommonTask(inProgress, 'id').status).toBe('TODO'); // IN-PROCESS has no Obsidian equivalent
 
       const cancelled = makeCalObj('c-can', 'Cancelled', ['STATUS:CANCELLED']);
       expect(adapter.toCommonTask(cancelled, 'id').status).toBe('CANCELLED');

--- a/src/sync/caldavAdapter.ts
+++ b/src/sync/caldavAdapter.ts
@@ -81,10 +81,14 @@ export class CalDAVAdapter {
    * Convert a CommonTask back to a VTODO iCal string. Injects the configured
    * caldavCategory into the outgoing CATEGORIES so the task stays identifiable
    * on the server even if user content tags don't include it.
+   *
+   * Pass `existingData` on update/complete paths so foreign properties
+   * (RELATED-TO, VALARM, X-* extensions, etc.) are preserved rather than
+   * silently deleted.
    */
-  fromCommonTask(task: CommonTask, caldavUID: string): string {
+  fromCommonTask(task: CommonTask, caldavUID: string, existingData?: string): string {
     const tags = injectTagIdentifier(task.tags, this.caldavCategory);
-    return this.mapper.taskToVTODO({ ...task, tags }, caldavUID);
+    return this.mapper.taskToVTODO({ ...task, tags }, caldavUID, existingData);
   }
 
   /**
@@ -107,7 +111,7 @@ export class CalDAVAdapter {
             console.error(`[CalDAVAdapter] VTODO ${caldavUID} not found for update, skipping`);
             continue;
           }
-          const newData = this.fromCommonTask(change.task, caldavUID);
+          const newData = this.fromCommonTask(change.task, caldavUID, existing.data);
           await this.client.updateVTODO(existing, newData);
           break;
         }
@@ -121,7 +125,7 @@ export class CalDAVAdapter {
             ...change.task,
             recurrenceRule: '',
           };
-          const newData = this.fromCommonTask(completedTask, caldavUID);
+          const newData = this.fromCommonTask(completedTask, caldavUID, existing.data);
           await this.client.updateVTODO(existing, newData);
           break;
         }

--- a/test/e2e/caldavAdapter.e2e.test.ts
+++ b/test/e2e/caldavAdapter.e2e.test.ts
@@ -378,6 +378,179 @@ describe('CalDAVAdapter E2E', () => {
     });
   });
 
+  describe('foreign property preservation (jtx Board / RFC 5545)', () => {
+    it('preserves RELATED-TO, VALARM, X- extension, and PERCENT-COMPLETE through an Obsidian update', async () => {
+      const client = makeClient();
+      const adapter = new CalDAVAdapter(client);
+      await client.connect();
+
+      const uid = `e2e-jtx-${Date.now()}`;
+      const jtxVTODO = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//jtx Board//EN',
+        'BEGIN:VTODO',
+        `UID:${uid}`,
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:Plan trip',
+        'STATUS:IN-PROCESS',
+        'PERCENT-COMPLETE:40',
+        'RELATED-TO;RELTYPE=PARENT:parent-uid-123',
+        'X-JTX-FOOBAR:custom-metadata',
+        'BEGIN:VALARM',
+        'ACTION:DISPLAY',
+        'DESCRIPTION:Reminder',
+        'TRIGGER:-PT15M',
+        'END:VALARM',
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      await client.createVTODO(jtxVTODO, uid);
+
+      const updatedTask: CommonTask = {
+        uid: 'obs-jtx',
+        title: 'Plan trip (updated)',
+        status: 'TODO',
+        dueDate: '2026-12-01',
+        startDate: null,
+        scheduledDate: null,
+        completedDate: null,
+        priority: 'high',
+        tags: [],
+        recurrenceRule: '',
+        body: '',
+      };
+
+      const idMapping: IdMapping = {
+        taskIdToCaldavUid: { 'obs-jtx': uid },
+        caldavUidToTaskId: { [uid]: 'obs-jtx' },
+      };
+      await adapter.applyChanges([{ type: 'update', task: updatedTask }], idMapping);
+
+      const vtodos = await client.fetchVTODOs();
+      expect(vtodos).toHaveLength(1);
+      const rawData = vtodos[0].data;
+
+      expect(rawData).toContain('RELATED-TO');
+      expect(rawData).toContain('parent-uid-123');
+      expect(rawData).toContain('X-JTX-FOOBAR:custom-metadata');
+      expect(rawData).toContain('BEGIN:VALARM');
+      expect(rawData).toContain('END:VALARM');
+      expect(rawData).toContain('PERCENT-COMPLETE:40');
+      expect(rawData).toContain('STATUS:IN-PROCESS'); // must survive the Obsidian update
+
+      const tasks = adapter.normalize(vtodos, emptyIdMapping);
+      expect(tasks[0].title).toBe('Plan trip (updated)');
+      expect(tasks[0].dueDate).toBe('2026-12-01');
+      expect(tasks[0].priority).toBe('high');
+    });
+
+    it('strips PERCENT-COMPLETE:40 and sets 100 on completion, preserves X- properties', async () => {
+      const client = makeClient();
+      const adapter = new CalDAVAdapter(client);
+      await client.connect();
+
+      const uid = `e2e-jtx-complete-${Date.now()}`;
+      const jtxVTODO = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//jtx Board//EN',
+        'BEGIN:VTODO',
+        `UID:${uid}`,
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:In progress task',
+        'STATUS:IN-PROCESS',
+        'PERCENT-COMPLETE:60',
+        'X-JTX-FOOBAR:preserved',
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      await client.createVTODO(jtxVTODO, uid);
+
+      const completedTask: CommonTask = {
+        uid: 'obs-jtx-done',
+        title: 'In progress task',
+        status: 'DONE',
+        dueDate: null,
+        startDate: null,
+        scheduledDate: null,
+        completedDate: '2026-07-18',
+        priority: 'none',
+        tags: [],
+        recurrenceRule: '',
+        body: '',
+      };
+
+      const idMapping: IdMapping = {
+        taskIdToCaldavUid: { 'obs-jtx-done': uid },
+        caldavUidToTaskId: { [uid]: 'obs-jtx-done' },
+      };
+      await adapter.applyChanges([{ type: 'complete', task: completedTask }], idMapping);
+
+      const vtodos = await client.fetchVTODOs();
+      const rawData = vtodos[0].data;
+
+      expect(rawData).toContain('PERCENT-COMPLETE:100');
+      expect(rawData).not.toContain('PERCENT-COMPLETE:60');
+      expect(rawData).toContain('X-JTX-FOOBAR:preserved');
+      expect(rawData).toContain('STATUS:COMPLETED');
+    });
+
+    it('preserves TZID and time-of-day on DUE through an Obsidian date change', async () => {
+      const client = makeClient();
+      const adapter = new CalDAVAdapter(client);
+      await client.connect();
+
+      const uid = `e2e-jtx-datetime-${Date.now()}`;
+      const jtxVTODO = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//jtx Board//EN',
+        'BEGIN:VTODO',
+        `UID:${uid}`,
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:Meeting prep',
+        'STATUS:IN-PROCESS',
+        'DUE;TZID=Europe/Berlin:20240115T140000',
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      await client.createVTODO(jtxVTODO, uid);
+
+      const updatedTask: CommonTask = {
+        uid: 'obs-dt',
+        title: 'Meeting prep',
+        status: 'TODO',
+        dueDate: '2026-09-01',
+        startDate: null,
+        scheduledDate: null,
+        completedDate: null,
+        priority: 'none',
+        tags: [],
+        recurrenceRule: '',
+        body: '',
+      };
+
+      const idMapping: IdMapping = {
+        taskIdToCaldavUid: { 'obs-dt': uid },
+        caldavUidToTaskId: { [uid]: 'obs-dt' },
+      };
+      await adapter.applyChanges([{ type: 'update', task: updatedTask }], idMapping);
+
+      const vtodos = await client.fetchVTODOs();
+      const rawData = vtodos[0].data;
+
+      // Date updated; timezone and time-of-day must be preserved
+      expect(rawData).toMatch(/DUE;TZID=Europe\/Berlin:20260901T140000/);
+      expect(rawData).not.toMatch(/DUE;VALUE=DATE/);
+      // STATUS:IN-PROCESS must also survive
+      expect(rawData).toContain('STATUS:IN-PROCESS');
+    });
+  });
+
   describe('fetchTasks category filter', () => {
     it('pulls every server task when the category is empty (iOS Reminders case, issue #94)', async () => {
       const client = makeClient();


### PR DESCRIPTION
## Summary

- **Preserve foreign VTODO properties on update**: when writing back a VTODO, any properties the plugin doesn't know about (`RELATED-TO`, `VALARM` blocks, `X-*` extension lines, `PERCENT-COMPLETE` when not completing, etc.) are round-tripped unchanged. Without this, a PUT update silently drops all unrecognised fields on every sync.
- **Preserve `STATUS:IN-PROCESS`**: jtx Board uses this status for in-progress tasks. The sync engine now treats it as open (`TODO`) so it does not generate a spurious update that would overwrite `IN-PROCESS` with `NEEDS-ACTION` on every sync cycle.
- **Preserve `DUE`/`DTSTART` datetime precision**: when the server stores a datetime value (with time-of-day and optional `TZID`), only the date digits are updated on sync; the time suffix and timezone pass through unchanged instead of being silently downgraded to `VALUE=DATE`.

## Motivation

Users of [jtx Board](https://jtx.techbee.at/) (Android CalDAV task manager) reported that syncing via this plugin corrupted their tasks — extra fields were stripped on every sync, and in-progress status was overwritten. These changes make the plugin safe to use alongside jtx Board and any other CalDAV client that writes properties beyond the plugin's own set.

## Test plan

- [ ] Unit tests cover foreign property round-trip (`vtodoMapper.test.ts`, `caldavAdapter.test.ts`)
- [ ] Unit tests cover `STATUS:IN-PROCESS` preservation
- [ ] Unit tests cover `DATE-TIME` precision preservation
- [ ] E2E tests cover full adapter round-trip (`caldavAdapter.e2e.test.ts`)
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)