### PR TITLE
fix(docs): correct DTSTART metadata mapping in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Use the "Inject task IDs" command to add IDs to existing tasks, or the plugin wi
 | Task text | SUMMARY | ↔ |
 | Indented bullets | DESCRIPTION | ↔ |
 | `📅` due date | DUE | ↔ |
-| `🛫` start date | DTSTART | ↔ |
+| `⏳` scheduled date | DTSTART | ↔ |
 | `✅` done date | COMPLETED | ↔ |
 | `🔁` recurrence | RRULE | ↔ |
 | Priority emoji | PRIORITY (1-9) | ↔ |


### PR DESCRIPTION
## Summary

The metadata mapping table incorrectly listed `🛫 start date → DTSTART`. `DTSTART` actually maps to the **scheduled date** (`⏳`). The start date has no CalDAV counterpart and is never synced (this is also documented in the code as an intentional invariant in the diff engine).

## Change

One-line fix in the README table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)