### PR TITLE
fix(ui): expose new tasks section setting in settings tab

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -397,6 +397,17 @@ class CalDAVSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
+			.setName('New tasks section')
+			.setDesc('Heading name (without #) in the destination file under which new tasks are inserted. Leave empty to append to the end of the file.')
+			.addText(text => text
+				.setPlaceholder('Inbox')
+				.setValue(this.plugin.settings.newTasksSection ?? '')
+				.onChange(async (value) => {
+					this.plugin.settings.newTasksSection = value || undefined;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
 			.setName('Include Obsidian link in synced tasks')
 			.setDesc('Embed a deep link to each synced task so you can open it in Obsidian from your calendar client. The link refreshes only when the task itself changes, so moving the source file will not update already-synced tasks. Existing link lines inside task bodies are stripped on sync-back.')
 			.addToggle(toggle => toggle

--- a/test/wdio/specs/newTasksSection.e2e.ts
+++ b/test/wdio/specs/newTasksSection.e2e.ts
@@ -1,0 +1,63 @@
+import { browser } from '@wdio/globals';
+import { createIsolatedCalendar } from '../../helpers/radicaleSetup';
+import { useCalendarUrl, syncNow } from '../helpers/pluginConfig';
+import { buildVtodoIcs, putVtodo } from '../helpers/serverVtodo';
+import { setFileContent } from '../helpers/vaultEdit';
+
+async function readVaultFile(filePath: string): Promise<string> {
+  return browser.executeObsidian(async ({ app }, args) => {
+    const f = app.vault.getAbstractFileByPath(args.filePath);
+    return f ? app.vault.read(f as any) : '';
+  }, { filePath });
+}
+
+describe('new tasks section setting', function () {
+  let calendarName: string;
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeEach(async function () {
+    const cal = await createIsolatedCalendar();
+    calendarName = cal.calendarName;
+    cleanup = cal.cleanup;
+    await useCalendarUrl(calendarName);
+    await setFileContent('Inbox.md', '# Inbox\n\n## Incoming\n\n## Done\n');
+  });
+
+  afterEach(async function () {
+    await browser.executeObsidian(async ({ app }) => {
+      const plugin = (app as any).plugins.plugins['tasks-caldav-sync'];
+      plugin.settings.newTasksSection = undefined;
+      await plugin.saveSettings();
+    });
+    await setFileContent('Inbox.md', '# Inbox\n');
+    await cleanup?.();
+  });
+
+  it('inserts new tasks under the configured heading instead of appending to end of file', async function () {
+    await browser.executeObsidian(async ({ app }) => {
+      const plugin = (app as any).plugins.plugins['tasks-caldav-sync'];
+      plugin.settings.newTasksSection = 'Incoming';
+      await plugin.saveSettings();
+    });
+
+    const uid = `wdio-section-${Date.now()}`;
+    const summary = `Section task ${Date.now()}`;
+    await putVtodo(calendarName, uid, buildVtodoIcs(uid, summary));
+
+    await syncNow();
+
+    await browser.waitUntil(async () => {
+      const content = await readVaultFile('Inbox.md');
+      return content.includes(summary);
+    }, { timeout: 15000, interval: 500, timeoutMsg: `task "${summary}" not written to Inbox.md` });
+
+    const content = await readVaultFile('Inbox.md');
+    const incomingPos = content.indexOf('## Incoming');
+    const donePos = content.indexOf('## Done');
+    const taskPos = content.indexOf(summary);
+
+    // Task must be between the two headings — not appended after "## Done"
+    expect(taskPos).toBeGreaterThan(incomingPos);
+    expect(taskPos).toBeLessThan(donePos);
+  });
+});


### PR DESCRIPTION
## Summary

`newTasksSection` existed in the settings type and was used by the adapter to insert incoming CalDAV tasks under a specific heading in the destination file — but was never exposed in the UI. Users had no way to configure it without manually editing `data.json`.

This adds the setting directly below **New tasks destination** in the settings tab:

- Empty (default) → tasks are appended to the end of the file (existing behaviour)
- Non-empty → tasks are inserted under the matching `#`/`##` heading; if the heading doesn't exist it is created at the end of the file

## Test plan

- [ ] Leave section empty — new tasks append to end of destination file
- [ ] Set section to an existing heading — new tasks appear under that heading
- [ ] Set section to a non-existent heading — heading is created, task inserted under it
- [ ] Setting persists across plugin reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)