### PR TITLE
fix(caldav): accept HTTP 200 as createVTODO success (DavMail overwrite)

### DIFF
--- a/src/caldav/calDAVClientDirect.ts
+++ b/src/caldav/calDAVClientDirect.ts
@@ -200,7 +200,11 @@ export class CalDAVClientDirect implements CalDAVClient {
       throw: false
     });
 
-    if (response.status !== 201 && response.status !== 204) {
+    // 200: some servers (e.g. DavMail) respond 200 OK when a PUT lands on an
+    // existing item name and is applied as an overwrite. Treating that as a
+    // failure aborts the sync before state is persisted, losing the id-mappings
+    // created earlier in the same run.
+    if (response.status !== 200 && response.status !== 201 && response.status !== 204) {
       throw new Error(`Create VTODO failed: ${response.status} for ${uid} at ${url} ${response.text}`);
     }
 

--- a/src/caldav/requestDumper.ts
+++ b/src/caldav/requestDumper.ts
@@ -358,7 +358,7 @@ export async function dumpCalDAVRequests(app: App, calendar: CalendarMapping): P
 		);
 		await saveExchange(step5.exchange);
 
-		if (step5.response.status !== 201 && step5.response.status !== 204) {
+		if (step5.response.status !== 200 && step5.response.status !== 201 && step5.response.status !== 204) {
 			throw new Error(`Create VTODO failed: ${step5.response.status}`);
 		}
 		addLog(`  Created (${step5.response.status})`);


### PR DESCRIPTION
## Summary

Now narrowed to a single fix, per review: **`createVTODO` treats HTTP 200 as success**, alongside 201/204 (matching `updateVTODO`, which already accepts 200). `requestDumper`'s create step gets the same treatment.

**Why:** DavMail (the Exchange/O365 CalDAV gateway) responds `200 OK` when a create-PUT lands on an existing item name and is applied as an overwrite. Treating 200 as a failure threw mid-`sync()`, which bailed before `storage.save()` — the id-mappings created earlier in the same run were lost, so every subsequent sync failed to match the tasks it had just pulled and re-created them with fresh IDs (an unbounded duplicate storm in steady state).

## Changes from the original PR

- **Baseline/uid keying fix — dropped.** Fixed at the root by #144. Confirmed the analysis there matches what I observed live (first-pull tasks fetched before their mapping exists).
- **`parseVTODOsFromXML` attributed-tag fix — dropped.** Superseded by the DOMParser refactor in #148, which already includes a DavMail-format test.
- Rebased on current master.

## Test plan

- `npm run test:unit` — 549/549 pass
- `tsc -noEmit -skipLibCheck` — clean
- Live validation against DavMail 6.6.0 (O365Interactive mode, Exchange Online / Microsoft To Do): a scripted round-trip suite (create both directions, complete vault→server, repeat syncs) passes 9/9 with this fix; without it, a single completed task left in the vault re-triggers the aborted-save path on every sync and duplicates all pulled tasks.

## Notes for DavMail users (not in this PR)

- DavMail hides `STATUS:COMPLETED` tasks from its `/tasks/` REPORT, so completed tasks "disappear" server-side; a `skip pushing unmapped DONE tasks` guard could avoid re-create churn.
- DavMail rejects task updates whose VTODO omits `PRIORITY` (HTTP 503, `ErrorInvalidPropertyDelete` on `item:Importance`). The plugin always emits `PRIORITY`, so it is unaffected.
- `syncCompletedTasks` in `CalDAVSettings` appears to be defined but never read (v1.5.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QD91BaYk5JjAXZpH2kSpP2
