### PR TITLE
fix(sync): assign the stable task ID when a CalDAV task is first pulled

### DIFF
--- a/src/sync/caldavAdapter.test.ts
+++ b/src/sync/caldavAdapter.test.ts
@@ -51,6 +51,7 @@ describe('CalDAVAdapter', () => {
       const task = adapter.toCommonTask(vtodo, 'my-task-id');
 
       expect(task.uid).toBe('my-task-id');
+      expect(task.caldavId).toBe('caldav-001');
       expect(task.title).toBe('Buy groceries');
       expect(task.status).toBe('TODO');
       expect(task.priority).toBe('none');
@@ -134,8 +135,12 @@ describe('CalDAVAdapter', () => {
 
       expect(tasks).toHaveLength(2);
       expect(tasks[0].uid).toBe('obsidian-id-123');
+      expect(tasks[0].caldavId).toBe('caldav-aaa');
       expect(tasks[0].title).toBe('Mapped task');
-      expect(tasks[1].uid).toBe('caldav-bbb');
+      // Unmapped: uid stays empty (never the raw CalDAV UID); the server
+      // identity lives only in caldavId.
+      expect(tasks[1].uid).toBe('');
+      expect(tasks[1].caldavId).toBe('caldav-bbb');
       expect(tasks[1].title).toBe('Unmapped task');
     });
 

--- a/src/sync/caldavAdapter.ts
+++ b/src/sync/caldavAdapter.ts
@@ -36,17 +36,19 @@ export class CalDAVAdapter {
   }
 
   /**
-   * Normalize VTODOs into CommonTask[], using IdMapping to resolve
-   * CalDAV UIDs to Obsidian task IDs where a mapping exists.
+   * Normalize VTODOs into CommonTask[]. The server identity always lands in
+   * `caldavId`; `uid` holds the mapped Obsidian task ID, or '' when the task
+   * has no local identity yet (the sync engine assigns one at discovery). The
+   * raw CalDAV UID is never used as a `uid` — the two keyspaces stay separate.
    */
   normalize(vtodos: CalendarObject[], idMapping: IdMapping): CommonTask[] {
     const tasks: CommonTask[] = [];
 
     for (const vtodo of vtodos) {
-      const caldavUid = this.mapper.extractUID(vtodo.data);
-      if (!caldavUid) continue;
+      const caldavId = this.mapper.extractUID(vtodo.data);
+      if (!caldavId) continue;
 
-      const uid = idMapping.caldavUidToTaskId[caldavUid] ?? caldavUid;
+      const uid = idMapping.caldavUidToTaskId[caldavId] ?? '';
       tasks.push(this.toCommonTask(vtodo, uid));
     }
 
@@ -54,7 +56,9 @@ export class CalDAVAdapter {
   }
 
   /**
-   * Convert a single VTODO CalendarObject to a CommonTask.
+   * Convert a single VTODO CalendarObject to a CommonTask. `uid` is the
+   * Obsidian task ID ('' when unmapped); `caldavId` is the server identity,
+   * derived here straight from the VTODO so it is always populated.
    */
   toCommonTask(vtodo: CalendarObject, uid: string): CommonTask {
     const parsed = this.mapper.vtodoToTask(vtodo);
@@ -62,6 +66,7 @@ export class CalDAVAdapter {
     return {
       ...parsed,
       uid,
+      caldavId: this.mapper.extractUID(vtodo.data),
       completedDate: parsed.completedDate ? this.toLocalDate(parsed.completedDate) : null,
     };
   }

--- a/src/sync/diff.ts
+++ b/src/sync/diff.ts
@@ -21,6 +21,16 @@ export function tasksEqual(a: CommonTask, b: CommonTask): boolean {
   );
 }
 
+/**
+ * Join key for a CalDAV task. A mapped task carries its stable Obsidian `uid`;
+ * a not-yet-assigned one carries only its server identity, so fall back to
+ * `caldavId`. This keeps unmapped server tasks uniquely keyed and prevents them
+ * from colliding with an Obsidian task under the empty string.
+ */
+function caldavKey(task: CommonTask): string {
+  return task.uid || task.caldavId || '';
+}
+
 function resolveChangeType(current: CommonTask, baseline: CommonTask): 'update' | 'complete' {
   if (baseline.status !== 'DONE' && current.status === 'DONE') {
     return 'complete';
@@ -50,7 +60,7 @@ export function diff(
   strategy: ConflictStrategy,
 ): Changeset {
   const obsidianByUid = new Map(obsidian.map(t => [t.uid, t]));
-  const caldavByUid = new Map(caldav.map(t => [t.uid, t]));
+  const caldavByUid = new Map(caldav.map(t => [caldavKey(t), t]));
   const baselineByUid = new Map(baseline.map(t => [t.uid, t]));
 
   const allUids = new Set([

--- a/src/sync/obsidianAdapter.ts
+++ b/src/sync/obsidianAdapter.ts
@@ -11,7 +11,6 @@ import { stripTagIdentifier } from "../utils/tagIdentifier";
 export type { TaskWithBody } from "../tasks/obsidianTasksWrapper";
 
 export interface ApplyChangesResult {
-	createdMappings: Array<{ taskId: string; caldavUID: string }>;
 	completionRemappings: Array<{ oldTaskId: string; newTaskId: string }>;
 }
 
@@ -45,6 +44,16 @@ export class ObsidianAdapter {
 
 	isReady(): boolean {
 		return this.wrapper.initialize();
+	}
+
+	/**
+	 * Mint a fresh, collision-free task ID drawn from this run's used-ID set
+	 * (populated from the whole vault during fetchTasks). Used by the sync
+	 * engine to give a first-time pulled CalDAV task its stable local identity
+	 * at discovery, before it is written to the vault.
+	 */
+	reserveTaskId(): string {
+		return generateTaskId(this.usedIds);
 	}
 
 	async fetchTasks(): Promise<CommonTask[]> {
@@ -113,10 +122,6 @@ export class ObsidianAdapter {
 		changes: SyncChange[],
 		onApplied?: () => void,
 	): Promise<ApplyChangesResult> {
-		const createdMappings: Array<{
-			taskId: string;
-			caldavUID: string;
-		}> = [];
 		const completionRemappings: Array<{
 			oldTaskId: string;
 			newTaskId: string;
@@ -128,13 +133,10 @@ export class ObsidianAdapter {
 			try {
 				switch (change.type) {
 					case "create": {
-						const taskId = generateTaskId(this.usedIds);
-						const taskWithId: CommonTask = {
-							...change.task,
-							uid: taskId,
-						};
+						// change.task.uid is already the stable local task ID,
+						// minted and mapped at discovery by the sync engine.
 						const markdown = this.mapper.toMarkdown(
-							taskWithId,
+							change.task,
 							this.settings.syncTag,
 							format,
 							globalFilter,
@@ -145,11 +147,6 @@ export class ObsidianAdapter {
 							this.settings.newTasksDestination,
 							this.settings.newTasksSection,
 						);
-
-						createdMappings.push({
-							taskId,
-							caldavUID: change.task.uid,
-						});
 						break;
 					}
 
@@ -226,7 +223,7 @@ export class ObsidianAdapter {
 			onApplied?.();
 		}
 
-		return { createdMappings, completionRemappings };
+		return { completionRemappings };
 	}
 
 	/**

--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -1177,6 +1177,48 @@ describe('SyncEngine', () => {
       expect(uids).toContain('20250101-aaa');
       expect(uids).toContain(mappedId);
     });
+
+    it('keys a reconciled server task by the matched vault ID, with no empty or raw-CalDAV entry', async () => {
+      // A vault task and a server task independently hold the same content with
+      // no prior mapping — diff reconciles them. The pulled CalDAV task arrives
+      // with uid === '' (only caldavId set); the "complete identities" step must
+      // stamp it with the matched vault task's ID BEFORE the baseline is built,
+      // or the baseline gets a stale empty/raw-UID entry that reads as a delete.
+      const vaultTask = makeObsidianTask({
+        description: 'Shared task',
+        id: '20250101-rec',
+        tags: ['#sync'],
+        originalMarkdown: '- [ ] Shared task [id::20250101-rec] #sync',
+      });
+      const serverTask = makeCalObj('caldav-rec', 'Shared task', ['CATEGORIES:sync']);
+
+      mockGetAllTasksWithBody.mockResolvedValue(withBody(vaultTask));
+      mockFetchVTODOs.mockResolvedValue([serverTask]);
+      mockGetBaseline.mockReturnValue([]);
+      mockGetIdMapping.mockReturnValue({ taskIdToCaldavUid: {}, caldavUidToTaskId: {} });
+
+      const engine = new SyncEngine(new App(), makeCalendarMapping(), makeSettings());
+      await engine.initialize();
+      const result = await engine.sync();
+
+      expect(result.success).toBe(true);
+      expect(result.reconciled).toBe(1);
+
+      const newBaseline = (mockSetBaseline.mock.calls[0] as [CommonTask[]])[0];
+      const uids = newBaseline.map((t: CommonTask) => t.uid).sort();
+
+      // Exactly one baseline entry, keyed by the matched vault ID — never the
+      // empty string and never the raw CalDAV UID.
+      expect(newBaseline.length).toBe(1);
+      expect(uids).toEqual(['20250101-rec']);
+      expect(uids).not.toContain('');
+      expect(uids).not.toContain('caldav-rec');
+
+      // The persisted mapping links the vault ID to the server UID both ways.
+      const idMapping = (mockSetIdMapping.mock.calls[0] as [IdMapping])[0];
+      expect(idMapping.taskIdToCaldavUid['20250101-rec']).toBe('caldav-rec');
+      expect(idMapping.caldavUidToTaskId['caldav-rec']).toBe('20250101-rec');
+    });
   });
 
   describe('idempotency', () => {

--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -1152,10 +1152,30 @@ describe('SyncEngine', () => {
       expect(mockSetBaseline).toHaveBeenCalledTimes(1);
 
       const newBaseline = (mockSetBaseline.mock.calls[0] as [CommonTask[]])[0];
-      expect(newBaseline.length).toBe(2);
       const uids = newBaseline.map((t: CommonTask) => t.uid).sort();
+
+      // The baseline must be keyed by the STABLE Obsidian task ID, never by the
+      // raw CalDAV UID. The stable ID is minted at discovery (when the pulled
+      // task is classified as a toObsidian `create`) and stamped onto that same
+      // task object, which is also the fetched caldavTasks entry — so both
+      // baseline sources already agree and collapse into a SINGLE entry.
+      // length === 2 is the duplicate guard.
+      expect(newBaseline.length).toBe(2);
+
+      // The raw CalDAV UID must NOT survive into the baseline: the next sync's
+      // fetch translates raw UIDs through the (now complete) mapping, so a
+      // raw-keyed baseline entry would never pair with the resolved fetch. The
+      // diff would then see no baseline and, under caldav-wins, silently revert
+      // any Obsidian-side edit of this server-originated task.
+      expect(uids).not.toContain('caldav-bbb');
+
+      // Instead the pulled task is keyed by the stable task ID that was minted
+      // for it during this sync and recorded in the persisted mapping.
+      const idMapping = (mockSetIdMapping.mock.calls[0] as [IdMapping])[0];
+      const mappedId = idMapping.caldavUidToTaskId['caldav-bbb'];
+      expect(mappedId).toBeDefined();
       expect(uids).toContain('20250101-aaa');
-      expect(uids).toContain('caldav-bbb');
+      expect(uids).toContain(mappedId);
     });
   });
 

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -92,6 +92,8 @@ export class SyncEngine {
 
 			if (dryRun) return this.buildResult(applicable, obsidianTasks, caldavTasks, baseline, true, showProgress);
 
+			this.assignPulledTaskIds(applicable.toObsidian, idMapping);
+
 			const progress: SyncProgress = {
 				pullDone: 0,
 				pullTotal: applicable.toObsidian.length,
@@ -100,7 +102,7 @@ export class SyncEngine {
 			};
 			onProgress?.({ ...progress });
 
-			const { createdMappings, completionRemappings } = await this.obsidianAdapter.applyChanges(
+			const { completionRemappings } = await this.obsidianAdapter.applyChanges(
 				applicable.toObsidian,
 				() => {
 					progress.pullDone++;
@@ -120,7 +122,7 @@ export class SyncEngine {
 				},
 			);
 
-			this.updateIdMapping(idMapping, createdMappings, completionRemappings, applicable);
+			this.updateIdMapping(idMapping, completionRemappings, applicable);
 			this.persistState(obsidianTasks, caldavTasks, applicable, idMapping);
 			await this.storage.save();
 
@@ -191,17 +193,35 @@ export class SyncEngine {
 		return baseline;
 	}
 
+	/**
+	 * Give every first-time pulled CalDAV task its stable local task ID at the
+	 * moment it is classified as a genuine "create in Obsidian".
+	 *
+	 * A `toObsidian` create is always CalDAV-sourced (it exists on the server
+	 * but not in the vault), and its `task.uid` still holds the raw CalDAV UID
+	 * from normalize's fallback. We mint the local ID here — after reconcile has
+	 * had its chance to pair the task with a pre-existing vault task — record it
+	 * in the mapping (preserving the raw UID so the server stays addressable),
+	 * and stamp it onto the change's task. Because that task is the same object
+	 * as the fetched caldavTasks entry, the new baseline becomes uniformly keyed
+	 * by the stable ID with no re-keying.
+	 */
+	private assignPulledTaskIds(toObsidian: SyncChange[], idMapping: IdMapping): void {
+		for (const change of toObsidian) {
+			if (change.type !== "create") continue;
+			const caldavUid = change.task.uid;
+			const taskId = this.obsidianAdapter.reserveTaskId();
+			idMapping.taskIdToCaldavUid[taskId] = caldavUid;
+			idMapping.caldavUidToTaskId[caldavUid] = taskId;
+			change.task.uid = taskId;
+		}
+	}
+
 	private updateIdMapping(
 		idMapping: IdMapping,
-		createdMappings: Array<{ taskId: string; caldavUID: string }>,
 		completionRemappings: Array<{ oldTaskId: string; newTaskId: string }>,
 		changeset: { toObsidian: SyncChange[]; toCalDAV: SyncChange[] },
 	): void {
-		for (const { taskId, caldavUID } of createdMappings) {
-			idMapping.taskIdToCaldavUid[taskId] = caldavUID;
-			idMapping.caldavUidToTaskId[caldavUID] = taskId;
-		}
-
 		for (const { oldTaskId, newTaskId } of completionRemappings) {
 			const caldavUID = idMapping.taskIdToCaldavUid[oldTaskId];
 			if (caldavUID) {

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -92,7 +92,7 @@ export class SyncEngine {
 
 			if (dryRun) return this.buildResult(applicable, obsidianTasks, caldavTasks, baseline, true, showProgress);
 
-			this.assignPulledTaskIds(applicable.toObsidian, idMapping);
+			this.completePulledIdentities(applicable, idMapping);
 
 			const progress: SyncProgress = {
 				pullDone: 0,
@@ -194,27 +194,44 @@ export class SyncEngine {
 	}
 
 	/**
-	 * Give every first-time pulled CalDAV task its stable local task ID at the
-	 * moment it is classified as a genuine "create in Obsidian".
+	 * Fill in the stable Obsidian `uid` on every CalDAV-sourced task that still
+	 * lacks one, before the new baseline is computed. A first-time-pulled task
+	 * arrives with `uid === ''` (only its `caldavId` is set); leaving it empty
+	 * would key the baseline by an empty or raw-CalDAV string and read as a
+	 * spurious delete on the next sync.
 	 *
-	 * A `toObsidian` create is always CalDAV-sourced (it exists on the server
-	 * but not in the vault), and its `task.uid` still holds the raw CalDAV UID
-	 * from normalize's fallback. We mint the local ID here — after reconcile has
-	 * had its chance to pair the task with a pre-existing vault task — record it
-	 * in the mapping (preserving the raw UID so the server stays addressable),
-	 * and stamp it onto the change's task. Because that task is the same object
-	 * as the fetched caldavTasks entry, the new baseline becomes uniformly keyed
-	 * by the stable ID with no re-keying.
+	 * The identity has two sources:
+	 *  - a genuine server create (`toObsidian` create): mint a fresh vault ID and
+	 *    register both mapping directions against the task's `caldavId`.
+	 *  - a reconcile (server task matched by content to an existing vault task):
+	 *    reuse the matched task's ID, carried on the change's `counterpartUid`.
+	 *
+	 * Each change's `task` is the same object as the fetched `caldavTasks` entry,
+	 * so stamping it here propagates straight into `computeNewBaseline` with no
+	 * re-keying. The server UID is always read from `caldavId`, never from `uid`.
 	 */
-	private assignPulledTaskIds(toObsidian: SyncChange[], idMapping: IdMapping): void {
-		for (const change of toObsidian) {
-			if (change.type !== "create") continue;
-			const caldavUid = change.task.uid;
-			const taskId = this.obsidianAdapter.reserveTaskId();
-			idMapping.taskIdToCaldavUid[taskId] = caldavUid;
-			idMapping.caldavUidToTaskId[caldavUid] = taskId;
-			change.task.uid = taskId;
+	private completePulledIdentities(
+		changeset: { toObsidian: SyncChange[]; toCalDAV: SyncChange[] },
+		idMapping: IdMapping,
+	): void {
+		for (const change of changeset.toObsidian) {
+			if (change.type === "create") {
+				change.task.uid = this.mintTaskIdForCaldav(change.task, idMapping);
+			}
 		}
+		for (const change of changeset.toCalDAV) {
+			if (change.type === "reconcile" && change.counterpartUid) {
+				change.task.uid = change.counterpartUid;
+			}
+		}
+	}
+
+	private mintTaskIdForCaldav(task: CommonTask, idMapping: IdMapping): string {
+		const caldavUid = task.caldavId ?? "";
+		const taskId = this.obsidianAdapter.reserveTaskId();
+		idMapping.taskIdToCaldavUid[taskId] = caldavUid;
+		idMapping.caldavUidToTaskId[caldavUid] = taskId;
+		return taskId;
 	}
 
 	private updateIdMapping(

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -2,7 +2,15 @@ export type TaskStatus = 'TODO' | 'DONE' | 'CANCELLED';
 export type TaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
 export interface CommonTask {
+  // The stable Obsidian task ID. Empty ('') until one has been assigned —
+  // a first-time-pulled CalDAV task carries no `uid` until the sync engine
+  // mints or matches one. Never a CalDAV server identity.
   uid: string;
+  // The CalDAV server identity (the VTODO UID). Derived on every fetch by
+  // caldavAdapter.normalize() and NEVER persisted: the baseline and IdMapping
+  // are keyed by `uid`, so this field only lives for the duration of a sync.
+  // Absent on Obsidian-sourced tasks.
+  caldavId?: string;
   title: string;
   status: TaskStatus;
   dueDate: string | null;       // 'YYYY-MM-DD'

--- a/test/e2e/baikal/baikal.e2e.test.ts
+++ b/test/e2e/baikal/baikal.e2e.test.ts
@@ -121,7 +121,7 @@ describe('Baïkal sync: full adapter cycle', () => {
     };
     const baseline: CommonTask[] = caldavTasks1.map(t => ({
       ...t,
-      uid: idMapping.caldavUidToTaskId[t.uid] ?? t.uid,
+      uid: idMapping.caldavUidToTaskId[t.caldavId ?? ''] ?? t.uid,
     }));
 
     const obsidianTasks: CommonTask[] = baseline.map(t => ({

--- a/test/e2e/caldavAdapter.e2e.test.ts
+++ b/test/e2e/caldavAdapter.e2e.test.ts
@@ -79,7 +79,9 @@ describe('CalDAVAdapter E2E', () => {
       const tasks = adapter.normalize(vtodos, emptyIdMapping);
 
       expect(tasks).toHaveLength(1);
-      expect(tasks[0].uid).toBe(uid);
+      // Unmapped: the server identity lands in caldavId, uid stays empty.
+      expect(tasks[0].uid).toBe('');
+      expect(tasks[0].caldavId).toBe(uid);
       expect(tasks[0].title).toBe('Buy milk');
       expect(tasks[0].status).toBe('TODO');
       expect(tasks[0].dueDate).toBe('2025-06-15');

--- a/test/e2e/nextcloud/nextcloud.e2e.test.ts
+++ b/test/e2e/nextcloud/nextcloud.e2e.test.ts
@@ -146,7 +146,7 @@ describe('Nextcloud sync: full adapter cycle (issue #64)', () => {
     };
     const baseline: CommonTask[] = caldavTasks1.map(t => ({
       ...t,
-      uid: idMapping.caldavUidToTaskId[t.uid] ?? t.uid,
+      uid: idMapping.caldavUidToTaskId[t.caldavId ?? ''] ?? t.uid,
     }));
 
     // Simulate Obsidian modified the task

--- a/test/e2e/syncRoundTrip.e2e.test.ts
+++ b/test/e2e/syncRoundTrip.e2e.test.ts
@@ -1,4 +1,5 @@
 import { CalDAVClientDirect } from '../../src/caldav/calDAVClientDirect';
+import { VTODOMapper, CalendarObject } from '../../src/caldav/vtodoMapper';
 import { CalDAVAdapter } from '../../src/sync/caldavAdapter';
 import { ObsidianMapper } from '../../src/tasks/obsidianMapper';
 import { diff } from '../../src/sync/diff';
@@ -10,12 +11,19 @@ import { RADICALE, createIsolatedCalendar } from '../helpers/radicaleSetup';
 
 const emptyIdMapping: IdMapping = { taskIdToCaldavUid: {}, caldavUidToTaskId: {} };
 
-// A CalDAV task that has already been synced carries a stable Obsidian uid.
-// These fixtures reuse the server UID as that id (the real case for tasks we
-// created), which normalize now leaves in caldavId — so lift it into uid to
-// stand in for the already-assigned Obsidian identity.
-function synced(tasks: CommonTask[]): CommonTask[] {
-  return tasks.map(t => ({ ...t, uid: t.caldavId ?? t.uid }));
+const mapper = new VTODOMapper();
+
+// Reproduce an already-synced fetch. These fixtures reuse the server UID as the
+// Obsidian id (the real case for plugin-created tasks), so normalize through the
+// id-mapping a prior sync would have persisted — exercising the real mapped path
+// rather than patching normalize's output after the fact.
+function normalizeSynced(adapter: CalDAVAdapter, vtodos: CalendarObject[]): CommonTask[] {
+  const ids = vtodos.map(v => mapper.extractUID(v.data)).filter(Boolean);
+  const mapping: IdMapping = {
+    caldavUidToTaskId: Object.fromEntries(ids.map(id => [id, id])),
+    taskIdToCaldavUid: Object.fromEntries(ids.map(id => [id, id])),
+  };
+  return adapter.normalize(vtodos, mapping);
 }
 
 const httpClient = new FetchHttpClient();
@@ -160,7 +168,7 @@ describe('Sync round-trip E2E', () => {
 
     // Establish baseline (previous sync)
     let vtodos = await client.fetchVTODOs();
-    const baseline = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
+    const baseline = normalizeSynced(caldavAdapter, vtodos);
 
     // Simulate CalDAV update (mark completed)
     const updatedVTODO = buildVTODO(uid, 'Original task', [
@@ -196,7 +204,7 @@ describe('Sync round-trip E2E', () => {
 
     // Establish baseline
     let vtodos = await client.fetchVTODOs();
-    const baseline = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
+    const baseline = normalizeSynced(caldavAdapter, vtodos);
 
     // Delete on CalDAV
     await client.deleteVTODO(vtodos[0]);
@@ -225,7 +233,7 @@ describe('Sync round-trip E2E', () => {
 
     // Establish baseline
     let vtodos = await client.fetchVTODOs();
-    const baseline = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
+    const baseline = normalizeSynced(caldavAdapter, vtodos);
 
     // CalDAV side: updated description
     const updatedVTODO = buildVTODO(uid, 'CalDAV version');
@@ -265,7 +273,7 @@ describe('Sync round-trip E2E', () => {
 
     // Establish baseline
     let vtodos = await client.fetchVTODOs();
-    const baseline = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
+    const baseline = normalizeSynced(caldavAdapter, vtodos);
     expect(baseline).toHaveLength(1);
     expect(baseline[0].recurrenceRule).toBe('FREQ=WEEKLY');
 
@@ -309,7 +317,7 @@ describe('Sync round-trip E2E', () => {
 
     // Fetch and normalize
     const vtodos = await client.fetchVTODOs();
-    const tasks = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
+    const tasks = normalizeSynced(caldavAdapter, vtodos);
     expect(tasks).toHaveLength(1);
     expect(tasks[0].recurrenceRule).toBe('FREQ=DAILY');
 
@@ -353,7 +361,7 @@ describe('Sync round-trip E2E', () => {
 
     // Establish baseline
     let vtodos = await client.fetchVTODOs();
-    const baseline = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
+    const baseline = normalizeSynced(caldavAdapter, vtodos);
     expect(baseline).toHaveLength(1);
     expect(baseline[0].dueDate).toBe('2026-02-17');
 
@@ -390,7 +398,7 @@ describe('Sync round-trip E2E', () => {
     await client.createVTODO(buildVTODO(delUid, 'Server task to delete locally'), delUid);
 
     // Baseline = what we last pulled.
-    const baseline = synced(caldavAdapter.normalize(await client.fetchVTODOs(), emptyIdMapping));
+    const baseline = normalizeSynced(caldavAdapter, await client.fetchVTODOs());
 
     // Obsidian diverges: edit one task, delete the other — locally only.
     const obsidianTasks: CommonTask[] = baseline
@@ -408,7 +416,7 @@ describe('Sync round-trip E2E', () => {
     const applied = applicableChanges(changeset, 'pull');
     await caldavAdapter.applyChanges(applied.toCalDAV, emptyIdMapping);
 
-    const after = synced(caldavAdapter.normalize(await client.fetchVTODOs(), emptyIdMapping));
+    const after = normalizeSynced(caldavAdapter, await client.fetchVTODOs());
     expect(after).toHaveLength(2);
     expect(after.find(t => t.uid === keepUid)?.title).toBe('Server task to edit'); // not 'Locally edited'
     expect(after.find(t => t.uid === delUid)).toBeDefined();                       // not deleted
@@ -449,7 +457,7 @@ describe('Sync round-trip E2E', () => {
 
     await caldavAdapter.applyChanges(applied.toCalDAV, emptyIdMapping);
 
-    const after = synced(caldavAdapter.normalize(await client.fetchVTODOs(), emptyIdMapping));
+    const after = normalizeSynced(caldavAdapter, await client.fetchVTODOs());
     expect(after).toHaveLength(2);                                                 // pushed task + untouched server task, nothing extra
     expect(after.find(t => t.title === 'Local task to push')).toBeDefined();      // push happened
     expect(after.find(t => t.uid === serverOnlyUid)).toBeDefined();               // untouched

--- a/test/e2e/syncRoundTrip.e2e.test.ts
+++ b/test/e2e/syncRoundTrip.e2e.test.ts
@@ -10,6 +10,14 @@ import { RADICALE, createIsolatedCalendar } from '../helpers/radicaleSetup';
 
 const emptyIdMapping: IdMapping = { taskIdToCaldavUid: {}, caldavUidToTaskId: {} };
 
+// A CalDAV task that has already been synced carries a stable Obsidian uid.
+// These fixtures reuse the server UID as that id (the real case for tasks we
+// created), which normalize now leaves in caldavId — so lift it into uid to
+// stand in for the already-assigned Obsidian identity.
+function synced(tasks: CommonTask[]): CommonTask[] {
+  return tasks.map(t => ({ ...t, uid: t.caldavId ?? t.uid }));
+}
+
 const httpClient = new FetchHttpClient();
 const obsidianMapper = new ObsidianMapper();
 
@@ -152,7 +160,7 @@ describe('Sync round-trip E2E', () => {
 
     // Establish baseline (previous sync)
     let vtodos = await client.fetchVTODOs();
-    const baseline = caldavAdapter.normalize(vtodos, emptyIdMapping);
+    const baseline = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
 
     // Simulate CalDAV update (mark completed)
     const updatedVTODO = buildVTODO(uid, 'Original task', [
@@ -188,7 +196,7 @@ describe('Sync round-trip E2E', () => {
 
     // Establish baseline
     let vtodos = await client.fetchVTODOs();
-    const baseline = caldavAdapter.normalize(vtodos, emptyIdMapping);
+    const baseline = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
 
     // Delete on CalDAV
     await client.deleteVTODO(vtodos[0]);
@@ -217,7 +225,7 @@ describe('Sync round-trip E2E', () => {
 
     // Establish baseline
     let vtodos = await client.fetchVTODOs();
-    const baseline = caldavAdapter.normalize(vtodos, emptyIdMapping);
+    const baseline = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
 
     // CalDAV side: updated description
     const updatedVTODO = buildVTODO(uid, 'CalDAV version');
@@ -257,7 +265,7 @@ describe('Sync round-trip E2E', () => {
 
     // Establish baseline
     let vtodos = await client.fetchVTODOs();
-    const baseline = caldavAdapter.normalize(vtodos, emptyIdMapping);
+    const baseline = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
     expect(baseline).toHaveLength(1);
     expect(baseline[0].recurrenceRule).toBe('FREQ=WEEKLY');
 
@@ -301,7 +309,7 @@ describe('Sync round-trip E2E', () => {
 
     // Fetch and normalize
     const vtodos = await client.fetchVTODOs();
-    const tasks = caldavAdapter.normalize(vtodos, emptyIdMapping);
+    const tasks = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
     expect(tasks).toHaveLength(1);
     expect(tasks[0].recurrenceRule).toBe('FREQ=DAILY');
 
@@ -345,7 +353,7 @@ describe('Sync round-trip E2E', () => {
 
     // Establish baseline
     let vtodos = await client.fetchVTODOs();
-    const baseline = caldavAdapter.normalize(vtodos, emptyIdMapping);
+    const baseline = synced(caldavAdapter.normalize(vtodos, emptyIdMapping));
     expect(baseline).toHaveLength(1);
     expect(baseline[0].dueDate).toBe('2026-02-17');
 
@@ -382,7 +390,7 @@ describe('Sync round-trip E2E', () => {
     await client.createVTODO(buildVTODO(delUid, 'Server task to delete locally'), delUid);
 
     // Baseline = what we last pulled.
-    const baseline = caldavAdapter.normalize(await client.fetchVTODOs(), emptyIdMapping);
+    const baseline = synced(caldavAdapter.normalize(await client.fetchVTODOs(), emptyIdMapping));
 
     // Obsidian diverges: edit one task, delete the other — locally only.
     const obsidianTasks: CommonTask[] = baseline
@@ -400,7 +408,7 @@ describe('Sync round-trip E2E', () => {
     const applied = applicableChanges(changeset, 'pull');
     await caldavAdapter.applyChanges(applied.toCalDAV, emptyIdMapping);
 
-    const after = caldavAdapter.normalize(await client.fetchVTODOs(), emptyIdMapping);
+    const after = synced(caldavAdapter.normalize(await client.fetchVTODOs(), emptyIdMapping));
     expect(after).toHaveLength(2);
     expect(after.find(t => t.uid === keepUid)?.title).toBe('Server task to edit'); // not 'Locally edited'
     expect(after.find(t => t.uid === delUid)).toBeDefined();                       // not deleted
@@ -441,7 +449,7 @@ describe('Sync round-trip E2E', () => {
 
     await caldavAdapter.applyChanges(applied.toCalDAV, emptyIdMapping);
 
-    const after = caldavAdapter.normalize(await client.fetchVTODOs(), emptyIdMapping);
+    const after = synced(caldavAdapter.normalize(await client.fetchVTODOs(), emptyIdMapping));
     expect(after).toHaveLength(2);                                                 // pushed task + untouched server task, nothing extra
     expect(after.find(t => t.title === 'Local task to push')).toBeDefined();      // push happened
     expect(after.find(t => t.uid === serverOnlyUid)).toBeDefined();               // untouched

--- a/test/e2e/vikunja/vikunjaSync.e2e.test.ts
+++ b/test/e2e/vikunja/vikunjaSync.e2e.test.ts
@@ -95,7 +95,7 @@ describe('Vikunja sync: issue #60 — server-created task duplication', () => {
     // Build new baseline (what both sides agree on after sync 1)
     const baselineAfterSync1: CommonTask[] = caldavTasks1.map(t => ({
       ...t,
-      uid: idMapping1.caldavUidToTaskId[t.uid] ?? t.uid,
+      uid: idMapping1.caldavUidToTaskId[t.caldavId ?? ''] ?? t.uid,
     }));
 
     // Simulate: Obsidian now has the task with obsidianTaskId
@@ -133,7 +133,7 @@ describe('Vikunja sync: issue #60 — server-created task duplication', () => {
     };
     const baseline: CommonTask[] = caldavTasks0.map(t => ({
       ...t,
-      uid: idMapping.caldavUidToTaskId[t.uid] ?? t.uid,
+      uid: idMapping.caldavUidToTaskId[t.caldavId ?? ''] ?? t.uid,
     }));
     const obsidianTasks: CommonTask[] = baseline.map(t => ({ ...t }));
 
@@ -182,7 +182,7 @@ describe('Vikunja sync: issue #60 — server-created task duplication', () => {
     };
     const baseline: CommonTask[] = caldavTasks1.map(t => ({
       ...t,
-      uid: idMapping.caldavUidToTaskId[t.uid] ?? t.uid,
+      uid: idMapping.caldavUidToTaskId[t.caldavId ?? ''] ?? t.uid,
     }));
     const obsidianTasks: CommonTask[] = baseline.map(t => ({ ...t }));
 


### PR DESCRIPTION
## The bug

Past the CalDAV adapter, the invariant is that every `CommonTask.uid` is the stable Obsidian task ID. A server task pulled for the **first time** broke it.

- `caldavAdapter.normalize()` resolves CalDAV UIDs to task IDs **at fetch time**. For a brand-new server task the mapping does not contain it yet, so it kept its **raw CalDAV UID** in `uid`.
- Its stable Obsidian task ID was only minted **later in the same sync** (inside `obsidianAdapter.applyChanges`).
- `computeNewBaseline()` then built the new baseline from those already-fetched lists, keying the pulled task by its **raw CalDAV UID**.

On the **next** sync, fetches translate UIDs through the now-complete mapping, so the raw-keyed baseline entry never pairs with the resolved fetch. The diff sees **no baseline** for the task and, under the default `caldav-wins` strategy, treats every Obsidian-side edit as a no-baseline conflict — so **checking off a pulled task in Obsidian gets silently reverted.**

## Fix, part 1: mint the task ID at discovery

Assign the stable local task ID at the **one** point a server task is classified as a genuine "create in Obsidian" — a `toObsidian` create in the changeset from `diff()`, after `reconcileOrphans` has had its chance to pair it with a pre-existing vault task. The engine reserves a fresh, collision-free vault ID via `obsidianAdapter.reserveTaskId()` (#115's used-ID set), registers the mapping both ways, and stamps it onto the change's `task` — which is the **same object** as the fetched `caldavTasks` entry, so `computeNewBaseline` becomes uniformly task-ID keyed with no re-keying.

## Fix, part 2: give CalDAV tasks their own id (`caldavId`)

Part 1 still read the raw CalDAV UID **out of** `CommonTask.uid` (`const caldavUid = change.task.uid`). That kept `uid` overloaded — sometimes an Obsidian id, sometimes a CalDAV UID. This part removes the overload:

- **`CommonTask.caldavId`** (new): the CalDAV server identity, derived per-fetch by `normalize()` and **never persisted**. The baseline and `IdMapping` keep their meaning (keyed by `uid`), so there is **no storage migration**.
- **`normalize()`** now sets `caldavId` = the VTODO UID **always**, and `uid` = the mapped Obsidian id or `''` when unmapped — **never** the raw CalDAV UID as a fallback. `uid` is now always the Obsidian id (or empty), never a CalDAV id.
- **`diff()`** keys the CalDAV side by `uid || caldavId`, so a not-yet-assigned server task stays uniquely keyed by its `caldavId` and cannot collide with an Obsidian task under the empty string.
- The create-only `assignPulledTaskIds` becomes a uniform **`completePulledIdentities`** step that fills the stable `uid` on **every** CalDAV-sourced task before the new baseline is computed:
  - **creates** — mint + register mapping against the task's `caldavId`;
  - **reconciles** — reuse the matched vault task's id (from `counterpartUid`), stamped onto the same `caldavTasks` object.

  The reconcile branch is the crux: without it a content-matched server task would keep `uid === ''` and leave a stale empty-keyed baseline entry that reads as a **spurious delete** on the next sync. The server UID is read from `caldavId`, never from `uid`.

`resolveStableUid` stays deleted; `computeNewBaseline`/`persistState` stay dumb — they consume already-correct `uid`s.

## Testing

- Full `npm test` (unit + E2E via Docker Radicale) — **559 passing**, coverage thresholds met.
- `npx tsc -noEmit -skipLibCheck` — clean. ESLint — clean.

New **reconcile-path baseline** test: a server task matched by content to an existing vault task yields exactly **one** baseline entry keyed by the vault id — no empty-uid or raw-CalDAV-id entry — cross-checked against the persisted `IdMapping`. The `baseline after sync`, `IdMapping updates after sync`, and `idempotency` suites confirm a second sync still produces zero changes. E2E fixtures that leaned on the old raw-UID fallback for shared identity now lift the stable id from `caldavId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
