### PR TITLE
refactor(caldav): parse and serialize VTODO with ical.js

### DIFF
--- a/MIGRATION-PLAN.md
+++ b/MIGRATION-PLAN.md
@@ -1,0 +1,72 @@
+# iCalendar handling migration to ical.js
+
+This documents a phased migration away from hand-rolled iCalendar/WebDAV
+string handling toward the [ical.js](https://github.com/kewisch/ical.js)
+engine (the parser that ships in Thunderbird — pure JS, browser-safe,
+ships its own TypeScript types).
+
+## Phase 1 — swap `VTODOMapper` internals to ical.js (this PR)
+
+- `src/caldav/vtodoMapper.ts` now parses and serializes VTODO with
+  ical.js instead of regex + manual line building. ical.js owns line
+  folding/unfolding, text escaping, `VALUE=DATE` handling, and component
+  scoping (`getFirstSubcomponent('vtodo')`), which removes the fragile
+  `BEGIN:VTODO…END:VTODO` slice and sub-component stripping.
+- **Behavior-preserving, interface unchanged.** `taskToVTODO`,
+  `vtodoToTask`, `extractUID`, `extractLastModified`, the `CalendarObject`
+  interface, and `getMapper()` usage are all identical. Adapters and the
+  CalDAV client are untouched.
+- **Domain rules preserved exactly:** inline `#tag` healing (#114), STATUS
+  mapping (TODO↔NEEDS-ACTION, IN_PROGRESS↔IN-PROCESS, DONE↔COMPLETED,
+  CANCELLED↔CANCELLED), the local-noon COMPLETED anchor (#43, still
+  computed by our own helper — ical.js only serializes the resolved UTC
+  instant, it does no timezone math), DTSTART→scheduledDate-only with
+  start date local-only (#131), priority bucket mapping, and CATEGORIES
+  comma/multi-line handling.
+- **RRULE stays a verbatim string.** We drive ical.js'
+  `design.icalendar.value.recur` (`fromICAL`/`toICAL`) directly rather
+  than the `ICAL.Recur` object, because `Recur.toString()` reorders the
+  rule parts. The plugin keeps translating natural-language recurrence
+  with the `rrule` package elsewhere; ical.js is not used for that.
+- All 517 unit tests (73 in `vtodoMapper.test.ts`) stay green with **no
+  test edits** — ical.js reproduces the same byte-level output (escaping,
+  folding, `VALUE=DATE`).
+- **Bundle delta:** `main.js` grows from 115,127 to 193,551 bytes
+  (+78,424 bytes, ~+76.6 KB minified). ical.js is bundled by esbuild (it
+  is intentionally *not* added to the `external` list).
+
+## Phase 2 — foreign-property round-trip on the write path (follow-up)
+
+- Extend the write path to `taskToVTODO(task, uid, existingData?)`: when
+  updating, parse the existing VTODO and mutate only the plugin-owned
+  properties, so `VALARM`, `RELATED-TO`, `X-*`, `VTIMEZONE`, and
+  `PERCENT-COMPLETE` set by other clients survive an update instead of
+  being dropped.
+- This is inherent to an ical.js round-trip (re-serialize the parsed
+  component) and **subsumes the manual merge approach in the open "jtx
+  Board compatibility" PR (#140)**. In particular it correctly handles
+  the `VTIMEZONE`-vs-`VTODO` `DTSTART` case that #140's document-wide
+  regex got wrong: a `VTIMEZONE` `STANDARD`/`DAYLIGHT` `DTSTART` lives in
+  a different component and must never be read as the task's `DTSTART` —
+  ical.js scopes to the VTODO component for free.
+- Requires small adapter changes to thread `existing.data` through on
+  update/complete (`src/sync/caldavAdapter.ts`).
+- The `IN-PROCESS` status semantic (#140 proposes IN-PROCESS→TODO) is a
+  separate decision to settle with that PR; Phase 1 keeps the current
+  IN-PROCESS↔IN_PROGRESS mapping.
+
+## Phase 3 — replace WebDAV XML parsing with `DOMParser` (follow-up)
+
+- Replace the regex WebDAV multistatus parsing in
+  `src/caldav/calDAVClientDirect.ts` (`parseVTODOsFromXML` plus the
+  href/etag/calendar-data regexes) with the platform `DOMParser`
+  (zero new dependency). **ical.js does not parse WebDAV XML** — this is a
+  separate, distinct cleanup from the VTODO work.
+- It also covers the attribute-on-tag case fixed by the DavMail PR (#143),
+  which the current regex mishandles.
+
+## What stays
+
+- **`rrule`** remains a dependency: it does English↔RRULE natural-language
+  translation (`fromText`/`toText`) on the Obsidian side, which ical.js
+  does not provide.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "tasks-caldav-sync",
-	"version": "1.3.0",
+	"version": "1.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tasks-caldav-sync",
-			"version": "1.3.0",
+			"version": "1.5.0",
 			"license": "MIT",
 			"dependencies": {
+				"ical.js": "^2.2.1",
 				"rrule": "^2.8.1"
 			},
 			"devDependencies": {
@@ -27,7 +28,7 @@
 				"globals": "^14.0.0",
 				"jest": "^30.2.0",
 				"jiti": "^2.6.1",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"obsidian-launcher": "^3.0.3",
 				"ts-jest": "^29.4.5",
 				"tslib": "2.4.0",
@@ -8078,6 +8079,12 @@
 			"engines": {
 				"node": ">=10.17.0"
 			}
+		},
+		"node_modules/ical.js": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
+			"integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
+			"license": "MPL-2.0"
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"wdio-obsidian-service": "^3.0.3"
 	},
 	"dependencies": {
+		"ical.js": "^2.2.1",
 		"rrule": "^2.8.1"
 	},
 	"overrides": {

--- a/src/caldav/vtodoMapper.ts
+++ b/src/caldav/vtodoMapper.ts
@@ -7,6 +7,7 @@ export interface CalendarObject {
   url: string;
 }
 
+import ICAL from 'ical.js';
 import { CommonTask } from '../sync/types';
 import { extractInlineTags, stripInlineTags } from '../utils/inlineTags';
 
@@ -14,7 +15,25 @@ import { extractInlineTags, stripInlineTags } from '../utils/inlineTags';
 type VTODOTaskFields = Omit<CommonTask, 'uid'>;
 
 /**
+ * The RRULE value serializer from ical.js' iCalendar design set. We drive it
+ * directly (instead of the `ICAL.Recur` object) so the rule survives as a
+ * verbatim string: `Recur.toString()` reorders parts, but `fromICAL`/`toICAL`
+ * preserve the author's original order. `design.*.value` is typed `any`, so we
+ * pin the two functions we use to a concrete shape here.
+ */
+interface RecurValueDesign {
+  fromICAL(value: string): object;
+  toICAL(value: object): string;
+}
+const RECUR_DESIGN = (ICAL.design.icalendar.value as Record<string, RecurValueDesign>).recur;
+
+/**
  * Maps between CommonTask fields and CalDAV VTODO iCalendar format.
+ *
+ * Parsing and serialization are delegated to ical.js (the Thunderbird engine):
+ * it owns line folding/unfolding, text escaping, VALUE=DATE handling and
+ * component scoping, so task fields are only ever read from the VTODO
+ * component — never from a sibling VTIMEZONE or a nested VALARM.
  */
 export class VTODOMapper {
   /**
@@ -24,66 +43,65 @@ export class VTODOMapper {
    * @returns VTODO iCalendar string
    */
   taskToVTODO(task: Omit<CommonTask, 'uid'>, uid: string): string {
-    const lines: string[] = [];
+    const calendar = new ICAL.Component(['vcalendar', [], []]);
+    calendar.updatePropertyWithValue('version', '2.0');
+    calendar.updatePropertyWithValue('prodid', '-//Obsidian//Tasks CalDAV Sync//EN');
 
-    lines.push('BEGIN:VCALENDAR');
-    lines.push('VERSION:2.0');
-    lines.push('PRODID:-//Obsidian//Tasks CalDAV Sync//EN');
-    lines.push('BEGIN:VTODO');
-    lines.push(`UID:${uid}`);
-    lines.push(`DTSTAMP:${this.formatDateTimeUTC(new Date())}`);
-    lines.push(`LAST-MODIFIED:${this.formatDateTimeUTC(new Date())}`);
-    lines.push(`SUMMARY:${this.escapeText(task.title)}`);
+    const vtodo = new ICAL.Component('vtodo');
+    calendar.addSubcomponent(vtodo);
 
-    // Description (body text), with optional obsidian link prepended
+    const now = ICAL.Time.fromJSDate(new Date(), true);
+    vtodo.updatePropertyWithValue('uid', uid);
+    vtodo.updatePropertyWithValue('dtstamp', now);
+    vtodo.updatePropertyWithValue('last-modified', now);
+    vtodo.updatePropertyWithValue('summary', task.title);
+
     const description = this.buildDescription(task.body, task.obsidianUrl);
     if (description) {
-      lines.push(`DESCRIPTION:${this.escapeText(description)}`);
+      vtodo.updatePropertyWithValue('description', description);
     }
 
     // Obsidian vault link. When set, this plugin owns the URL property —
     // any value previously set by another CalDAV client will be overwritten.
     if (task.obsidianUrl) {
-      lines.push(`URL:${task.obsidianUrl}`);
+      vtodo.updatePropertyWithValue('url', task.obsidianUrl);
     }
 
-    // Status mapping
-    lines.push(`STATUS:${this.mapStatusToVTODO(task.status)}`);
+    vtodo.updatePropertyWithValue('status', this.mapStatusToVTODO(task.status));
 
-    // Due date
     if (task.dueDate) {
-      lines.push(`DUE;VALUE=DATE:${this.formatDate(task.dueDate)}`);
+      vtodo.updatePropertyWithValue('due', this.toDateValue(task.dueDate));
     }
 
     // DTSTART carries the scheduled date (⏳) — the field CalDAV clients plan
     // by. The start date (🛫) has no CalDAV counterpart and never syncs.
     if (task.scheduledDate) {
-      lines.push(`DTSTART;VALUE=DATE:${this.formatDate(task.scheduledDate)}`);
+      vtodo.updatePropertyWithValue('dtstart', this.toDateValue(task.scheduledDate));
     }
 
-    // Completed date
     if (task.completedDate) {
-      lines.push(`COMPLETED:${this.formatDateTimeUTC(this.toCompletedInstant(task.completedDate))}`);
-      lines.push('PERCENT-COMPLETE:100');
+      // Anchor and format the completion instant ourselves (issue #43) — ical.js
+      // only serializes the already-resolved UTC instant, it does no timezone math.
+      vtodo.updatePropertyWithValue(
+        'completed',
+        ICAL.Time.fromJSDate(this.toCompletedInstant(task.completedDate), true),
+      );
+      vtodo.updatePropertyWithValue('percent-complete', 100);
     }
 
-    // Priority mapping (Obsidian: lowest/low/none/medium/high/highest -> VTODO: 0-9)
-    lines.push(`PRIORITY:${this.mapPriorityToVTODO(task.priority)}`);
+    vtodo.updatePropertyWithValue('priority', this.mapPriorityToVTODO(task.priority));
 
-    // Recurrence rule
     if (task.recurrenceRule) {
-      lines.push(`RRULE:${task.recurrenceRule}`);
+      vtodo.addProperty(this.buildRecurrenceProperty(task.recurrenceRule, vtodo));
     }
 
-    // Tags as categories
     if (task.tags.length > 0) {
-      lines.push(`CATEGORIES:${task.tags.map(t => this.escapeText(t)).join(',')}`);
+      const categories = new ICAL.Property('categories', vtodo);
+      categories.setValues(task.tags);
+      vtodo.addProperty(categories);
     }
 
-    lines.push('END:VTODO');
-    lines.push('END:VCALENDAR');
-
-    return lines.join('\r\n');
+    return calendar.toString();
   }
 
   /**
@@ -91,30 +109,24 @@ export class VTODOMapper {
    * @param vtodo The CalDAV calendar object containing VTODO
    */
   vtodoToTask(vtodo: CalendarObject): VTODOTaskFields {
-    const unfolded = this.unfold(vtodo.data);
-    // Extract only the VTODO section to avoid matching properties from VTIMEZONE or other components,
-    // then strip sub-components (VALARM etc.) so their properties don't bleed into task fields
-    // — a sub-component's DESCRIPTION is not the task's description.
-    const vtodoMatch = unfolded.match(/BEGIN:VTODO[\s\S]*?END:VTODO/);
-    const data = (vtodoMatch ? vtodoMatch[0] : unfolded)
-      .replace(/BEGIN:(?!VTODO\b)\w+[\s\S]*?END:\w+(\r?\n|$)/g, '');
+    const component = this.parseVTODO(vtodo.data);
 
     // Inline #tags in SUMMARY (written by older plugin versions or other
     // clients) move into tags[], so corrupted tasks heal instead of gaining
     // a duplicate tag on every sync — issue #114.
-    const summary = this.extractRawProperty(data, 'SUMMARY') || '';
+    const summary = this.stringValue(component, 'summary');
 
     return {
       title: stripInlineTags(summary) || 'Untitled Task',
-      status: this.mapStatusFromVTODO(this.extractProperty(data, 'STATUS') || 'NEEDS-ACTION') as CommonTask['status'],
-      dueDate: this.extractDateProperty(data, 'DUE'),
-      scheduledDate: this.extractDateProperty(data, 'DTSTART'),
+      status: this.mapStatusFromVTODO(this.stringValue(component, 'status') || 'NEEDS-ACTION') as CommonTask['status'],
+      dueDate: this.extractDate(component, 'due'),
+      scheduledDate: this.extractDate(component, 'dtstart'),
       startDate: null,
-      completedDate: this.extractDateTimeProperty(data, 'COMPLETED'),
-      priority: this.mapPriorityFromVTODO(this.extractProperty(data, 'PRIORITY') || '0') as CommonTask['priority'],
-      recurrenceRule: this.extractProperty(data, 'RRULE') || '',
-      tags: this.dedupeTags([...this.extractCategories(data), ...extractInlineTags(summary)]),
-      body: this.stripObsidianLinks(this.extractRawProperty(data, 'DESCRIPTION') || ''),
+      completedDate: this.extractDateTime(component, 'completed'),
+      priority: this.mapPriorityFromVTODO(this.stringValue(component, 'priority') || '0') as CommonTask['priority'],
+      recurrenceRule: this.extractRecurrence(component),
+      tags: this.dedupeTags([...this.extractCategories(component), ...extractInlineTags(summary)]),
+      body: this.stripObsidianLinks(this.stringValue(component, 'description')),
     };
   }
 
@@ -122,9 +134,7 @@ export class VTODOMapper {
    * Extract UID from VTODO data
    */
   extractUID(data: string): string {
-    const unfolded = this.unfold(data);
-    const match = unfolded.match(/^UID:(.+)$/m);
-    return match ? match[1].trim() : '';
+    return this.stringValue(this.parseVTODO(data), 'uid');
   }
 
   /**
@@ -132,19 +142,75 @@ export class VTODOMapper {
    * Returns ISO 8601 string or null if not present
    */
   extractLastModified(data: string): string | null {
-    const match = this.unfold(data).match(/^LAST-MODIFIED:(.+)$/m);
-    if (!match) return null;
+    return this.extractDateTime(this.parseVTODO(data), 'last-modified');
+  }
 
-    const timestamp = match[1].trim();
-    // Parse iCalendar datetime format (YYYYMMDDTHHMMSSZ)
-    const year = timestamp.substring(0, 4);
-    const month = timestamp.substring(4, 6);
-    const day = timestamp.substring(6, 8);
-    const hour = timestamp.substring(9, 11);
-    const minute = timestamp.substring(11, 13);
-    const second = timestamp.substring(13, 15);
+  /**
+   * Parse iCalendar data and return its VTODO component. Accepts both a full
+   * VCALENDAR wrapper and a bare VTODO. Falls back to an empty component so
+   * callers still read defaults from VTODO-less input.
+   */
+  private parseVTODO(data: string): ICAL.Component {
+    // ICAL.parse returns jCal typed as `any`; a component's jCal is an array.
+    const root = new ICAL.Component(ICAL.parse(data) as unknown[]);
+    if (root.name === 'vtodo') return root;
+    return root.getFirstSubcomponent('vtodo') ?? new ICAL.Component('vtodo');
+  }
 
-    return `${year}-${month}-${day}T${hour}:${minute}:${second}Z`;
+  /** First property value as a string, '' when the property is absent. */
+  private stringValue(component: ICAL.Component, name: string): string {
+    const value = component.getFirstPropertyValue(name);
+    return value === null ? '' : String(value);
+  }
+
+  /** A date-only ICAL.Time from a 'YYYY-MM-DD' string, emitted as VALUE=DATE. */
+  private toDateValue(date: string): ICAL.Time {
+    const [year, month, day] = date.split('-').map(Number);
+    return ICAL.Time.fromData({ year, month, day, isDate: true });
+  }
+
+  /**
+   * Read a date property as 'YYYY-MM-DD', taking only the calendar-day portion
+   * of VALUE=DATE, TZID and datetime forms alike.
+   */
+  private extractDate(component: ICAL.Component, name: string): string | null {
+    const time = component.getFirstPropertyValue(name);
+    if (!(time instanceof ICAL.Time)) return null;
+    return `${this.pad(time.year, 4)}-${this.pad(time.month, 2)}-${this.pad(time.day, 2)}`;
+  }
+
+  /** Read a datetime property as 'YYYY-MM-DDTHH:MM:SSZ' from its wall-clock components. */
+  private extractDateTime(component: ICAL.Component, name: string): string | null {
+    const time = component.getFirstPropertyValue(name);
+    if (!(time instanceof ICAL.Time) || time.isDate) return null;
+    return (
+      `${this.pad(time.year, 4)}-${this.pad(time.month, 2)}-${this.pad(time.day, 2)}` +
+      `T${this.pad(time.hour, 2)}:${this.pad(time.minute, 2)}:${this.pad(time.second, 2)}Z`
+    );
+  }
+
+  /**
+   * The RRULE is stored and round-tripped as a verbatim string (issue #8): the
+   * plugin translates natural-language recurrence elsewhere and never mutates
+   * the rule, so read it straight from the value serializer rather than an
+   * `ICAL.Recur` object (whose `toString()` reorders the parts).
+   */
+  private extractRecurrence(component: ICAL.Component): string {
+    const property = component.getFirstProperty('rrule');
+    if (!property) return '';
+    return RECUR_DESIGN.toICAL(property.jCal[3] as object);
+  }
+
+  private buildRecurrenceProperty(rule: string, parent: ICAL.Component): ICAL.Property {
+    return new ICAL.Property(['rrule', {}, 'recur', RECUR_DESIGN.fromICAL(rule)], parent);
+  }
+
+  /**
+   * Extract categories (tags). ical.js unescapes and splits multi-value
+   * CATEGORIES; multiple CATEGORIES lines are concatenated, as servers emit both.
+   */
+  private extractCategories(component: ICAL.Component): string[] {
+    return component.getAllProperties('categories').flatMap((property) => property.getValues() as string[]);
   }
 
   /**
@@ -217,118 +283,6 @@ export class VTODOMapper {
     return 'lowest';
   }
 
-  /**
-   * RFC 5545 Section 3.1: Unfold long content lines.
-   * Lines folded with CRLF+space/tab continuation are joined.
-   */
-  private unfold(data: string): string {
-    return data.replace(/\r?\n[ \t]/g, '');
-  }
-
-  /**
-   * Extract a simple property value from iCalendar data
-   */
-  private extractProperty(data: string, property: string): string | null {
-    const regex = new RegExp(`^${property}[;:](.+)$`, 'm');
-    const match = data.match(regex);
-
-    if (match) {
-      // Extract value after last colon (handles parameters like DUE;VALUE=DATE:20250105)
-      const fullValue = match[1];
-      const colonIndex = fullValue.lastIndexOf(':');
-      const value = colonIndex >= 0 ? fullValue.substring(colonIndex + 1).trim() : fullValue.trim();
-
-      // Unescape iCalendar special characters
-      return this.unescapeText(value);
-    }
-
-    return null;
-  }
-
-  /**
-   * Extract a property value without splitting on colons within the value.
-   * Used for DESCRIPTION and other text properties where colons are valid content.
-   */
-  private extractRawProperty(data: string, property: string): string | null {
-    const regex = new RegExp(`^${property}:(.+)$`, 'm');
-    const match = data.match(regex);
-    if (!match) return null;
-    return this.unescapeText(match[1].trim());
-  }
-
-  /**
-   * Extract date property (VALUE=DATE format)
-   */
-  private extractDateProperty(data: string, property: string): string | null {
-    const value = this.extractProperty(data, property);
-    if (!value) return null;
-
-    // Parse YYYYMMDD format (VALUE=DATE)
-    if (value.length === 8 && /^\d{8}$/.test(value)) {
-      const year = value.substring(0, 4);
-      const month = value.substring(4, 6);
-      const day = value.substring(6, 8);
-      return `${year}-${month}-${day}`;
-    }
-
-    // Parse YYYYMMDDTHHMMSS format (TZID parameter or datetime without Z)
-    if (value.length >= 15 && value.includes('T')) {
-      const year = value.substring(0, 4);
-      const month = value.substring(4, 6);
-      const day = value.substring(6, 8);
-      return `${year}-${month}-${day}`;
-    }
-
-    return null;
-  }
-
-  /**
-   * Extract datetime property
-   */
-  private extractDateTimeProperty(data: string, property: string): string | null {
-    const value = this.extractProperty(data, property);
-    if (!value) return null;
-
-    // Parse YYYYMMDDTHHMMSSZ format
-    if (value.length >= 15 && value.includes('T')) {
-      const year = value.substring(0, 4);
-      const month = value.substring(4, 6);
-      const day = value.substring(6, 8);
-      const hour = value.substring(9, 11);
-      const minute = value.substring(11, 13);
-      const second = value.substring(13, 15);
-      return `${year}-${month}-${day}T${hour}:${minute}:${second}Z`;
-    }
-
-    return null;
-  }
-
-  /**
-   * Extract categories (tags)
-   * Handles both comma-separated (CATEGORIES:a,b,c) and multiple lines
-   * (CATEGORIES:a\nCATEGORIES:b) as servers use both formats.
-   */
-  private extractCategories(data: string): string[] {
-    const regex = /^CATEGORIES[;:](.+)$/gm;
-    const categories: string[] = [];
-    let match;
-
-    while ((match = regex.exec(data)) !== null) {
-      // Extract value after last colon (handles parameters)
-      const fullValue = match[1];
-      const colonIndex = fullValue.lastIndexOf(':');
-      const value = colonIndex >= 0 ? fullValue.substring(colonIndex + 1).trim() : fullValue.trim();
-
-      // Split by unescaped commas: split on commas that aren't preceded by backslash
-      const parts = value.split(/(?<!\\),/);
-      for (const part of parts) {
-        categories.push(this.unescapeText(part.trim()));
-      }
-    }
-
-    return categories;
-  }
-
   /** Case-insensitive, order-preserving dedupe — Obsidian treats tags case-insensitively. */
   private dedupeTags(tags: string[]): string[] {
     const seen = new Set<string>();
@@ -340,23 +294,8 @@ export class VTODOMapper {
     });
   }
 
-  /**
-   * Format date as YYYYMMDD
-   * For date-only strings (YYYY-MM-DD), parses without timezone conversion
-   */
-  private formatDate(dateInput: Date | string): string {
-    // If it's already a YYYY-MM-DD string, parse it directly without timezone issues
-    if (typeof dateInput === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(dateInput)) {
-      const [year, month, day] = dateInput.split('-');
-      return `${year}${month}${day}`;
-    }
-
-    // Otherwise treat as Date object (use local time)
-    const date = dateInput instanceof Date ? dateInput : new Date(dateInput);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}${month}${day}`;
+  private pad(value: number, length: number): string {
+    return String(value).padStart(length, '0');
   }
 
   /**
@@ -374,30 +313,6 @@ export class VTODOMapper {
     return new Date(completedDate);
   }
 
-  /**
-   * Format datetime as YYYYMMDDTHHMMSSZ (UTC)
-   */
-  private formatDateTimeUTC(date: Date): string {
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(date.getUTCDate()).padStart(2, '0');
-    const hour = String(date.getUTCHours()).padStart(2, '0');
-    const minute = String(date.getUTCMinutes()).padStart(2, '0');
-    const second = String(date.getUTCSeconds()).padStart(2, '0');
-    return `${year}${month}${day}T${hour}${minute}${second}Z`;
-  }
-
-  /**
-   * Escape special characters in iCalendar text
-   */
-  private escapeText(text: string): string {
-    return text
-      .replace(/\\/g, '\\\\')
-      .replace(/;/g, '\\;')
-      .replace(/,/g, '\\,')
-      .replace(/\n/g, '\\n');
-  }
-
   private buildDescription(body: string, obsidianUrl?: string): string {
     if (!obsidianUrl && !body) return '';
     if (!obsidianUrl) return body;
@@ -409,16 +324,5 @@ export class VTODOMapper {
     const lines = body.split('\n');
     const filtered = lines.filter(line => !line.match(/^obsidian:\/\/open\?vault=/));
     return filtered.join('\n').replace(/^\n+/, '');
-  }
-
-  /**
-   * Unescape special characters from iCalendar text
-   */
-  private unescapeText(text: string): string {
-    return text
-      .replace(/\\n/g, '\n')
-      .replace(/\\,/g, ',')
-      .replace(/\\;/g, ';')
-      .replace(/\\\\/g, '\\');
   }
 }


### PR DESCRIPTION
## What

Phase 1 of migrating iCalendar handling to [ical.js](https://github.com/kewisch/ical.js) (the Thunderbird engine — pure JS, browser-safe, ships its own TS types). This swaps the internals of `src/caldav/vtodoMapper.ts` from regex + manual line building to ical.js parse/serialize.

- Public interface unchanged: `taskToVTODO`, `vtodoToTask`, `extractUID`, `extractLastModified`, the `CalendarObject` interface, and `getMapper()` usage are identical. Adapters and the CalDAV client are untouched.
- Adds `ical.js@^2.2.1` as a runtime dependency (bundled by esbuild, intentionally not in the `external` list).

## Why

- Kill the fragile hand-rolled parsing: the `BEGIN:VTODO…END:VTODO` slice, the sub-component-stripping regex, and the per-property colon/fold logic. ical.js owns line folding/unfolding, text escaping, `VALUE=DATE` handling, and component scoping (`getFirstSubcomponent('vtodo')`), so task fields are only ever read from the VTODO component — never a sibling VTIMEZONE or nested VALARM.
- Foundation for a proper round-trip (Phase 2), which is inherently how ical.js works.

## Domain rules preserved exactly

- Inline `#tag` healing (#114), STATUS mapping (TODO↔NEEDS-ACTION, IN_PROGRESS↔IN-PROCESS, DONE↔COMPLETED, CANCELLED↔CANCELLED), local-noon COMPLETED anchor (#43, still computed by our own helper — ical.js only serializes the resolved UTC instant, no timezone math), DTSTART→scheduledDate-only with start date local-only (#131), priority buckets, CATEGORIES comma/multi-line handling.
- **RRULE stays a verbatim string** via the recur value design (`fromICAL`/`toICAL`) rather than `ICAL.Recur` (whose `toString()` reorders the parts). The `rrule` package still does natural-language recurrence elsewhere and is untouched.

## Results

- **Unit:** 517/517 pass (73 in `vtodoMapper.test.ts`) with **no test edits** — ical.js reproduces the same byte-level output (escaping, folding, `VALUE=DATE`).
- **Typecheck:** `tsc -noEmit -skipLibCheck` clean.
- **Lint:** `eslint .` clean.
- **Build:** succeeds. `main.js` grows **115,127 → 193,551 bytes (+78,424, ~+76.6 KB minified)** — ical.js is bundled.
- **E2E:** Radicale CalDAV suite (caldavClient/caldavAdapter/syncRoundTrip) run locally — 29/29 pass.

## Follow-up plan (see `MIGRATION-PLAN.md`)

- **Phase 2:** foreign-property round-trip on the write path — `taskToVTODO(task, uid, existingData?)` parses the existing VTODO and mutates only plugin-owned properties, so VALARM / RELATED-TO / X-* / VTIMEZONE / PERCENT-COMPLETE survive updates. This is inherent to ical.js round-trip and **subsumes the manual merge in #140**, including the VTIMEZONE-vs-VTODO `DTSTART` case #140's document-wide regex got wrong. Requires small adapter changes to thread `existing.data`. The IN-PROCESS status semantic is a separate decision to settle with #140.
- **Phase 3:** replace the WebDAV XML regex parsing in `calDAVClientDirect.ts` with the platform `DOMParser` (zero new dependency) — ical.js does not parse WebDAV XML. Also covers the attribute-on-tag case fixed by #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
