### PR TITLE
feat(caldav): round-trip foreign VTODO properties and preserve IN-PROCESS via ical.js

### DIFF
--- a/src/caldav/vtodoMapper.test.ts
+++ b/src/caldav/vtodoMapper.test.ts
@@ -1,3 +1,4 @@
+import ICAL from 'ical.js';
 import { VTODOMapper, CalendarObject } from './vtodoMapper';
 import { CommonTask, TaskStatus, TaskPriority } from '../sync/types';
 import { ObsidianMapper } from '../tasks/obsidianMapper';
@@ -72,9 +73,11 @@ describe('VTODOMapper - pure functions for VTODO<->Task conversion', () => {
     });
 
     it('should map all status values correctly', () => {
+      // IN_PROGRESS was removed from the status union: obsidian-tasks has no
+      // in-progress checkbox, so the plugin never produces it. On the fresh
+      // create path TODO is always written as NEEDS-ACTION.
       const statuses = [
         { obsidian: 'TODO', vtodo: 'NEEDS-ACTION' },
-        { obsidian: 'IN_PROGRESS', vtodo: 'IN-PROCESS' },
         { obsidian: 'DONE', vtodo: 'COMPLETED' },
         { obsidian: 'CANCELLED', vtodo: 'CANCELLED' }
       ];
@@ -318,9 +321,12 @@ END:VTODO`;
     });
 
     it('should map all VTODO statuses correctly', () => {
+      // IN-PROCESS reads back as TODO: obsidian-tasks has no in-progress
+      // checkbox, so mapping it to a distinct state produced a phantom diff
+      // that rewrote NEEDS-ACTION over the server's IN-PROCESS every sync.
       const statuses = [
         { vtodo: 'NEEDS-ACTION', obsidian: 'TODO' },
-        { vtodo: 'IN-PROCESS', obsidian: 'IN_PROGRESS' },
+        { vtodo: 'IN-PROCESS', obsidian: 'TODO' },
         { vtodo: 'COMPLETED', obsidian: 'DONE' },
         { vtodo: 'CANCELLED', obsidian: 'CANCELLED' }
       ];
@@ -1428,6 +1434,217 @@ END:VTODO`;
 
       expect(back.scheduledDate).toBe('2026-07-10');
       expect(back.startDate).toBeNull();
+    });
+  });
+
+  // Part A/B: on the update/complete path taskToVTODO parses the server body
+  // and mutates only plugin-owned properties, so foreign properties and
+  // sub-components survive. This subsumes PR #140 (jtx Board compatibility)
+  // via the ical.js component tree instead of document-wide regexes.
+  describe('foreign-property round-trip (existingData)', () => {
+    const openTask: Omit<CommonTask, 'uid'> = {
+      title: 'Edited title',
+      status: 'TODO',
+      dueDate: null,
+      scheduledDate: null,
+      startDate: null,
+      completedDate: null,
+      priority: 'none',
+      recurrenceRule: '',
+      tags: [],
+      body: '',
+    };
+
+    function parseVTODO(ics: string): ICAL.Component {
+      const root = new ICAL.Component(ICAL.parse(ics) as unknown[]);
+      return root.name === 'vtodo' ? root : root.getFirstSubcomponent('vtodo')!;
+    }
+
+    function serverVTODO(lines: string[]): string {
+      return [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//Foreign App//EN',
+        'BEGIN:VTODO',
+        'UID:foreign-uid',
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:Original title',
+        ...lines,
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+    }
+
+    it('preserves VALARM, RELATED-TO and X-* extension properties', () => {
+      const existing = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//jtx Board//EN',
+        'BEGIN:VTODO',
+        'UID:foreign-uid',
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:Original title',
+        'STATUS:NEEDS-ACTION',
+        'RELATED-TO;RELTYPE=PARENT:parent-task-uid',
+        'X-JTX-BOARD-COLOR:#ff0000',
+        'BEGIN:VALARM',
+        'TRIGGER:-PT15M',
+        'ACTION:DISPLAY',
+        'DESCRIPTION:Reminder text',
+        'END:VALARM',
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      const out = mapper.taskToVTODO(openTask, 'foreign-uid', existing);
+      const vtodo = parseVTODO(out);
+
+      expect(vtodo.getFirstPropertyValue('summary')).toBe('Edited title');
+      expect(vtodo.getFirstProperty('related-to')).not.toBeNull();
+      expect(vtodo.getFirstPropertyValue('related-to')).toBe('parent-task-uid');
+      expect(vtodo.getFirstPropertyValue('x-jtx-board-color')).toBe('#ff0000');
+      const valarm = vtodo.getFirstSubcomponent('valarm');
+      expect(valarm).not.toBeNull();
+      expect(valarm!.getFirstPropertyValue('trigger')).not.toBeNull();
+      expect(valarm!.getFirstPropertyValue('description')).toBe('Reminder text');
+    });
+
+    it('leaves an in-progress PERCENT-COMPLETE untouched on an open update', () => {
+      const existing = serverVTODO(['STATUS:IN-PROCESS', 'PERCENT-COMPLETE:42']);
+      const out = mapper.taskToVTODO(openTask, 'foreign-uid', existing);
+      const vtodo = parseVTODO(out);
+      expect(vtodo.getFirstPropertyValue('percent-complete')).toBe(42);
+    });
+
+    it('strips PERCENT-COMPLETE up to 100 on completion', () => {
+      const existing = serverVTODO(['STATUS:IN-PROCESS', 'PERCENT-COMPLETE:42']);
+      const completing = { ...openTask, status: 'DONE' as const, completedDate: '2026-03-01' };
+      const out = mapper.taskToVTODO(completing, 'foreign-uid', existing);
+      const vtodo = parseVTODO(out);
+      expect(vtodo.getFirstPropertyValue('percent-complete')).toBe(100);
+      expect(vtodo.getFirstPropertyValue('status')).toBe('COMPLETED');
+      expect(vtodo.getFirstPropertyValue('completed')).not.toBeNull();
+    });
+
+    describe('STATUS semantics on the round-trip', () => {
+      it('preserves the server STATUS:IN-PROCESS when an open task title is edited', () => {
+        const existing = serverVTODO(['STATUS:IN-PROCESS']);
+        const out = mapper.taskToVTODO(openTask, 'foreign-uid', existing);
+        const vtodo = parseVTODO(out);
+        expect(vtodo.getFirstPropertyValue('status')).toBe('IN-PROCESS');
+        expect(vtodo.getFirstPropertyValue('summary')).toBe('Edited title');
+      });
+
+      it('passes NEEDS-ACTION through for an open task', () => {
+        const existing = serverVTODO(['STATUS:NEEDS-ACTION']);
+        const out = mapper.taskToVTODO(openTask, 'foreign-uid', existing);
+        expect(parseVTODO(out).getFirstPropertyValue('status')).toBe('NEEDS-ACTION');
+      });
+
+      it('overrides STATUS to COMPLETED on a terminal DONE transition', () => {
+        const existing = serverVTODO(['STATUS:IN-PROCESS']);
+        const done = { ...openTask, status: 'DONE' as const, completedDate: '2026-03-01' };
+        const out = mapper.taskToVTODO(done, 'foreign-uid', existing);
+        expect(parseVTODO(out).getFirstPropertyValue('status')).toBe('COMPLETED');
+      });
+
+      it('overrides STATUS to CANCELLED on a terminal CANCELLED transition', () => {
+        const existing = serverVTODO(['STATUS:IN-PROCESS']);
+        const cancelled = { ...openTask, status: 'CANCELLED' as const };
+        const out = mapper.taskToVTODO(cancelled, 'foreign-uid', existing);
+        expect(parseVTODO(out).getFirstPropertyValue('status')).toBe('CANCELLED');
+      });
+    });
+
+    // F1 regression from PR #140: a document-wide DTSTART regex corrupts the
+    // task DTSTART by matching a VTIMEZONE rule's DTSTART. Reading the property
+    // off the VTODO component makes that structurally impossible.
+    describe('F1: VTIMEZONE DTSTART collision', () => {
+      const withTimezone = (line: string): string => [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//DAVx5//EN',
+        'BEGIN:VTIMEZONE',
+        'TZID:Europe/Berlin',
+        'BEGIN:DAYLIGHT',
+        'DTSTART:19700329T020000',
+        'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3',
+        'TZOFFSETFROM:+0100',
+        'TZOFFSETTO:+0200',
+        'END:DAYLIGHT',
+        'BEGIN:STANDARD',
+        'DTSTART:19701025T030000',
+        'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10',
+        'TZOFFSETFROM:+0200',
+        'TZOFFSETTO:+0100',
+        'END:STANDARD',
+        'END:VTIMEZONE',
+        'BEGIN:VTODO',
+        'UID:tz-task',
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:Original',
+        'STATUS:NEEDS-ACTION',
+        line,
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      it('updates the DTSTART date while preserving TZID and time-of-day', () => {
+        const existing = withTimezone('DTSTART;TZID=Europe/Berlin:20260214T083000');
+        const rescheduled = { ...openTask, scheduledDate: '2026-07-20' };
+        const out = mapper.taskToVTODO(rescheduled, 'tz-task', existing);
+        const vtodo = parseVTODO(out);
+        const dtstart = vtodo.getFirstProperty('dtstart')!;
+        const value = dtstart.getFirstValue() as ICAL.Time;
+
+        expect(dtstart.getParameter('tzid')).toBe('Europe/Berlin');
+        expect(value.isDate).toBe(false);
+        // New date, original time-of-day — never the 02:00 VTIMEZONE rule time.
+        expect(value.year).toBe(2026);
+        expect(value.month).toBe(7);
+        expect(value.day).toBe(20);
+        expect(value.hour).toBe(8);
+        expect(value.minute).toBe(30);
+        // Not downgraded to VALUE=DATE, and not the VTIMEZONE rule's DTSTART.
+        expect(dtstart.toICALString()).toBe('DTSTART;TZID=Europe/Berlin:20260720T083000');
+      });
+
+      it('updates a UTC (Z) DUE date while preserving its time-of-day', () => {
+        const existing = withTimezone('DUE:20260215T093000Z');
+        const rescheduled = { ...openTask, dueDate: '2026-08-01' };
+        const out = mapper.taskToVTODO(rescheduled, 'tz-task', existing);
+        const vtodo = parseVTODO(out);
+        const due = vtodo.getFirstProperty('due')!;
+        const value = due.getFirstValue() as ICAL.Time;
+
+        expect(value.isDate).toBe(false);
+        expect(value.zone).toBe(ICAL.Timezone.utcTimezone);
+        expect(due.toICALString()).toBe('DUE:20260801T093000Z');
+      });
+
+      it('updates a TZID DUE date while preserving TZID and time-of-day', () => {
+        const existing = withTimezone('DUE;TZID=Europe/Berlin:20260215T170000');
+        const rescheduled = { ...openTask, dueDate: '2026-08-01' };
+        const out = mapper.taskToVTODO(rescheduled, 'tz-task', existing);
+        const due = parseVTODO(out).getFirstProperty('due')!;
+
+        expect(due.getParameter('tzid')).toBe('Europe/Berlin');
+        expect(due.toICALString()).toBe('DUE;TZID=Europe/Berlin:20260801T170000');
+      });
+
+      it('downgrades to VALUE=DATE when the server value was already date-only', () => {
+        const existing = withTimezone('DTSTART;VALUE=DATE:20260214');
+        const rescheduled = { ...openTask, scheduledDate: '2026-07-20' };
+        const out = mapper.taskToVTODO(rescheduled, 'tz-task', existing);
+        const dtstart = parseVTODO(out).getFirstProperty('dtstart')!;
+        expect(dtstart.toICALString()).toBe('DTSTART;VALUE=DATE:20260720');
+      });
+
+      it('removes DTSTART when the task no longer has a scheduled date', () => {
+        const existing = withTimezone('DTSTART;TZID=Europe/Berlin:20260214T083000');
+        const out = mapper.taskToVTODO(openTask, 'tz-task', existing);
+        expect(parseVTODO(out).getFirstProperty('dtstart')).toBeNull();
+      });
     });
   });
 });

--- a/src/caldav/vtodoMapper.ts
+++ b/src/caldav/vtodoMapper.ts
@@ -37,71 +37,165 @@ const RECUR_DESIGN = (ICAL.design.icalendar.value as Record<string, RecurValueDe
  */
 export class VTODOMapper {
   /**
-   * Convert a CommonTask to VTODO iCalendar string.
+   * Convert a CommonTask to a VTODO iCalendar string.
+   *
    * @param task The common task
-   * @param uid The CalDAV UID (use for updates, generate new for creates)
+   * @param uid The CalDAV UID (reused on update, freshly generated on create)
+   * @param existingData The untouched server VTODO body on the update/complete
+   *   path. When present the plugin mutates only its own properties on the
+   *   parsed component tree and lets every foreign property and sub-component
+   *   (VALARM, RELATED-TO, X-*, VTIMEZONE, …) pass through verbatim. When
+   *   absent a fresh VTODO is built from scratch.
    * @returns VTODO iCalendar string
    */
-  taskToVTODO(task: Omit<CommonTask, 'uid'>, uid: string): string {
+  taskToVTODO(task: Omit<CommonTask, 'uid'>, uid: string, existingData?: string): string {
+    return existingData
+      ? this.mergeIntoExisting(task, existingData)
+      : this.buildFreshVTODO(task, uid);
+  }
+
+  private buildFreshVTODO(task: Omit<CommonTask, 'uid'>, uid: string): string {
     const calendar = new ICAL.Component(['vcalendar', [], []]);
     calendar.updatePropertyWithValue('version', '2.0');
     calendar.updatePropertyWithValue('prodid', '-//Obsidian//Tasks CalDAV Sync//EN');
 
     const vtodo = new ICAL.Component('vtodo');
     calendar.addSubcomponent(vtodo);
-
-    const now = ICAL.Time.fromJSDate(new Date(), true);
     vtodo.updatePropertyWithValue('uid', uid);
+    this.applyOwnedProperties(vtodo, task, false);
+
+    return calendar.toString();
+  }
+
+  /**
+   * Round-trip write: parse the server body, mutate only the plugin-owned
+   * properties on its VTODO component, and serialize. Because every edit is
+   * scoped to the VTODO component, a sibling VTIMEZONE rule's DTSTART can never
+   * be mistaken for the task's DTSTART, and foreign lines/sub-components are
+   * preserved and folded by ical.js rather than hand-spliced.
+   */
+  private mergeIntoExisting(task: Omit<CommonTask, 'uid'>, existingData: string): string {
+    // ICAL.parse returns jCal typed as `any`; a component's jCal is an array.
+    const root = new ICAL.Component(ICAL.parse(existingData) as unknown[]);
+    const vtodo = root.name === 'vtodo' ? root : (root.getFirstSubcomponent('vtodo') ?? root);
+    this.applyOwnedProperties(vtodo, task, true);
+    return root.toString();
+  }
+
+  /**
+   * Set every plugin-owned property on the VTODO component. On the update path
+   * (`isUpdate`) the server's value is preserved for the few properties the
+   * plugin can't fully own: STATUS while the task is still open, PERCENT-COMPLETE
+   * while it isn't completing, and the time-of-day/TZID of DUE and DTSTART.
+   */
+  private applyOwnedProperties(vtodo: ICAL.Component, task: Omit<CommonTask, 'uid'>, isUpdate: boolean): void {
+    const now = ICAL.Time.fromJSDate(new Date(), true);
     vtodo.updatePropertyWithValue('dtstamp', now);
     vtodo.updatePropertyWithValue('last-modified', now);
     vtodo.updatePropertyWithValue('summary', task.title);
 
-    const description = this.buildDescription(task.body, task.obsidianUrl);
-    if (description) {
-      vtodo.updatePropertyWithValue('description', description);
-    }
+    this.setOrRemove(vtodo, 'description', this.buildDescription(task.body, task.obsidianUrl));
 
-    // Obsidian vault link. When set, this plugin owns the URL property —
-    // any value previously set by another CalDAV client will be overwritten.
+    // Obsidian vault link. When set, this plugin owns the URL property — any
+    // value previously set by another CalDAV client is overwritten. When unset
+    // the plugin isn't managing URL, so a foreign URL is left untouched.
     if (task.obsidianUrl) {
       vtodo.updatePropertyWithValue('url', task.obsidianUrl);
     }
 
-    vtodo.updatePropertyWithValue('status', this.mapStatusToVTODO(task.status));
-
-    if (task.dueDate) {
-      vtodo.updatePropertyWithValue('due', this.toDateValue(task.dueDate));
-    }
-
-    // DTSTART carries the scheduled date (⏳) — the field CalDAV clients plan
-    // by. The start date (🛫) has no CalDAV counterpart and never syncs.
-    if (task.scheduledDate) {
-      vtodo.updatePropertyWithValue('dtstart', this.toDateValue(task.scheduledDate));
-    }
-
-    if (task.completedDate) {
-      // Anchor and format the completion instant ourselves (issue #43) — ical.js
-      // only serializes the already-resolved UTC instant, it does no timezone math.
-      vtodo.updatePropertyWithValue(
-        'completed',
-        ICAL.Time.fromJSDate(this.toCompletedInstant(task.completedDate), true),
-      );
-      vtodo.updatePropertyWithValue('percent-complete', 100);
-    }
-
+    this.applyStatus(vtodo, task.status, isUpdate);
+    // DUE and DTSTART carry the plugin's date-only values; DTSTART is the
+    // scheduled date (⏳) that CalDAV clients plan by. The start date (🛫) has
+    // no CalDAV counterpart and never syncs.
+    this.applyDate(vtodo, 'due', task.dueDate);
+    this.applyDate(vtodo, 'dtstart', task.scheduledDate);
+    this.applyCompletion(vtodo, task.completedDate);
     vtodo.updatePropertyWithValue('priority', this.mapPriorityToVTODO(task.priority));
+    this.applyRecurrence(vtodo, task.recurrenceRule);
+    this.applyCategories(vtodo, task.tags);
+  }
 
-    if (task.recurrenceRule) {
-      vtodo.addProperty(this.buildRecurrenceProperty(task.recurrenceRule, vtodo));
+  private setOrRemove(vtodo: ICAL.Component, name: string, value: string): void {
+    if (value) {
+      vtodo.updatePropertyWithValue(name, value);
+    } else {
+      vtodo.removeAllProperties(name);
+    }
+  }
+
+  /**
+   * An open task (TODO) never overwrites the server's STATUS on update:
+   * obsidian-tasks has no in-progress checkbox, so IN-PROCESS is kept as-is
+   * and NEEDS-ACTION passes through. Only terminal states are written
+   * (DONE→COMPLETED, CANCELLED→CANCELLED). A fresh VTODO always states TODO as
+   * NEEDS-ACTION since there is nothing to preserve.
+   */
+  private applyStatus(vtodo: ICAL.Component, status: CommonTask['status'], isUpdate: boolean): void {
+    if (isUpdate && status === 'TODO') return;
+    vtodo.updatePropertyWithValue('status', this.mapStatusToVTODO(status));
+  }
+
+  /**
+   * Write a date-only value, preserving the time-of-day and TZID of an existing
+   * DATE-TIME property so a server's `DUE;TZID=…:…T…` keeps its clock time and
+   * zone and is only moved to the new calendar day. The existing property is
+   * read off the VTODO component, never a document-wide search, so a sibling
+   * VTIMEZONE rule's DTSTART cannot be picked up. A date-only or absent existing
+   * value is written as VALUE=DATE; removing the date removes the property.
+   */
+  private applyDate(vtodo: ICAL.Component, name: string, date: string | null): void {
+    if (!date) {
+      vtodo.removeAllProperties(name);
+      return;
     }
 
-    if (task.tags.length > 0) {
-      const categories = new ICAL.Property('categories', vtodo);
-      categories.setValues(task.tags);
-      vtodo.addProperty(categories);
+    const existing = vtodo.getFirstProperty(name);
+    const existingTime = existing?.getFirstValue();
+    if (existing && existingTime instanceof ICAL.Time && !existingTime.isDate) {
+      const [year, month, day] = date.split('-').map(Number);
+      existingTime.year = year;
+      existingTime.month = month;
+      existingTime.day = day;
+      existing.setValue(existingTime);
+      return;
     }
 
-    return calendar.toString();
+    vtodo.removeAllProperties(name);
+    vtodo.updatePropertyWithValue(name, this.toDateValue(date));
+  }
+
+  /**
+   * On completion, anchor and format the completion instant ourselves (issue
+   * #43) — ical.js only serializes the already-resolved UTC instant — and force
+   * PERCENT-COMPLETE to 100. While the task is open, COMPLETED is cleared but
+   * PERCENT-COMPLETE is left untouched so a server's in-progress value survives.
+   */
+  private applyCompletion(vtodo: ICAL.Component, completedDate: string | null): void {
+    if (!completedDate) {
+      vtodo.removeAllProperties('completed');
+      return;
+    }
+    vtodo.updatePropertyWithValue(
+      'completed',
+      ICAL.Time.fromJSDate(this.toCompletedInstant(completedDate), true),
+    );
+    vtodo.removeAllProperties('percent-complete');
+    vtodo.updatePropertyWithValue('percent-complete', 100);
+  }
+
+  private applyRecurrence(vtodo: ICAL.Component, rule: string): void {
+    vtodo.removeAllProperties('rrule');
+    if (rule) {
+      vtodo.addProperty(this.buildRecurrenceProperty(rule, vtodo));
+    }
+  }
+
+  private applyCategories(vtodo: ICAL.Component, tags: string[]): void {
+    vtodo.removeAllProperties('categories');
+    if (tags.length === 0) return;
+    const categories = new ICAL.Property('categories', vtodo);
+    categories.setValues(tags);
+    vtodo.addProperty(categories);
   }
 
   /**
@@ -220,8 +314,6 @@ export class VTODOMapper {
     switch (status) {
       case 'TODO':
         return 'NEEDS-ACTION';
-      case 'IN_PROGRESS':
-        return 'IN-PROCESS';
       case 'DONE':
         return 'COMPLETED';
       case 'CANCELLED':
@@ -232,14 +324,17 @@ export class VTODOMapper {
   }
 
   /**
-   * Map VTODO status to Obsidian task status
+   * Map VTODO status to Obsidian task status. IN-PROCESS maps to TODO because
+   * obsidian-tasks has no in-progress checkbox: mapping it to a distinct state
+   * created a permanent phantom diff that rewrote NEEDS-ACTION over the server's
+   * IN-PROCESS on every sync. The write path preserves IN-PROCESS instead.
    */
   private mapStatusFromVTODO(status: string): string {
     switch (status) {
       case 'NEEDS-ACTION':
         return 'TODO';
       case 'IN-PROCESS':
-        return 'IN_PROGRESS';
+        return 'TODO';
       case 'COMPLETED':
         return 'DONE';
       case 'CANCELLED':

--- a/src/sync/caldavAdapter.test.ts
+++ b/src/sync/caldavAdapter.test.ts
@@ -73,8 +73,10 @@ describe('CalDAVAdapter', () => {
       const done = makeCalObj('c-done', 'Done task', ['STATUS:COMPLETED']);
       expect(adapter.toCommonTask(done, 'id').status).toBe('DONE');
 
+      // IN-PROCESS reads back as TODO — obsidian-tasks has no in-progress
+      // checkbox, and the write path preserves the server's IN-PROCESS instead.
       const inProgress = makeCalObj('c-ip', 'In progress', ['STATUS:IN-PROCESS']);
-      expect(adapter.toCommonTask(inProgress, 'id').status).toBe('IN_PROGRESS');
+      expect(adapter.toCommonTask(inProgress, 'id').status).toBe('TODO');
 
       const cancelled = makeCalObj('c-can', 'Cancelled', ['STATUS:CANCELLED']);
       expect(adapter.toCommonTask(cancelled, 'id').status).toBe('CANCELLED');
@@ -458,7 +460,7 @@ describe('CalDAVAdapter', () => {
 
     it('should call update for update changes', async () => {
       const mockFetchVTODOByUID = jest.fn().mockResolvedValue({
-        data: 'old vtodo data',
+        data: buildVTODO('caldav-upd', 'Existing task'),
         url: 'http://example.com/task.ics',
         etag: 'old-etag',
       });

--- a/src/sync/caldavAdapter.ts
+++ b/src/sync/caldavAdapter.ts
@@ -80,11 +80,13 @@ export class CalDAVAdapter {
   /**
    * Convert a CommonTask back to a VTODO iCal string. Injects the configured
    * caldavCategory into the outgoing CATEGORIES so the task stays identifiable
-   * on the server even if user content tags don't include it.
+   * on the server even if user content tags don't include it. On update/complete
+   * `existingData` is the untouched server body; the mapper mutates only
+   * plugin-owned properties and lets foreign properties pass through.
    */
-  fromCommonTask(task: CommonTask, caldavUID: string): string {
+  fromCommonTask(task: CommonTask, caldavUID: string, existingData?: string): string {
     const tags = injectTagIdentifier(task.tags, this.caldavCategory);
-    return this.mapper.taskToVTODO({ ...task, tags }, caldavUID);
+    return this.mapper.taskToVTODO({ ...task, tags }, caldavUID, existingData);
   }
 
   /**
@@ -107,7 +109,7 @@ export class CalDAVAdapter {
             console.error(`[CalDAVAdapter] VTODO ${caldavUID} not found for update, skipping`);
             continue;
           }
-          const newData = this.fromCommonTask(change.task, caldavUID);
+          const newData = this.fromCommonTask(change.task, caldavUID, existing.data);
           await this.client.updateVTODO(existing, newData);
           break;
         }
@@ -121,7 +123,7 @@ export class CalDAVAdapter {
             ...change.task,
             recurrenceRule: '',
           };
-          const newData = this.fromCommonTask(completedTask, caldavUID);
+          const newData = this.fromCommonTask(completedTask, caldavUID, existing.data);
           await this.client.updateVTODO(existing, newData);
           break;
         }

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -1,4 +1,4 @@
-export type TaskStatus = 'TODO' | 'IN_PROGRESS' | 'DONE' | 'CANCELLED';
+export type TaskStatus = 'TODO' | 'DONE' | 'CANCELLED';
 export type TaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
 export interface CommonTask {

--- a/test/e2e/caldavAdapter.e2e.test.ts
+++ b/test/e2e/caldavAdapter.e2e.test.ts
@@ -1,3 +1,4 @@
+import ICAL from 'ical.js';
 import { CalDAVClientDirect } from '../../src/caldav/calDAVClientDirect';
 import { CalDAVAdapter } from '../../src/sync/caldavAdapter';
 import { CommonTask } from '../../src/sync/types';
@@ -375,6 +376,187 @@ describe('CalDAVAdapter E2E', () => {
 
       const updated = tasks.find(t => t.title === 'Updated existing task');
       expect(updated?.status).toBe('DONE');
+    });
+  });
+
+  // Radicale is not jtx Board, so these fixtures prove the round-trip against a
+  // real server: create a VTODO carrying foreign properties, apply an update
+  // through the adapter, then fetch and assert the foreign data survived.
+  // This is the evidence that subsumes PR #140.
+  describe('foreign-property round-trip (issue #140 / jtx Board)', () => {
+    const openTask = (uid: string, title: string, extra: Partial<CommonTask> = {}): CommonTask => ({
+      uid,
+      title,
+      status: 'TODO',
+      dueDate: null,
+      startDate: null,
+      scheduledDate: null,
+      completedDate: null,
+      priority: 'none',
+      tags: [],
+      recurrenceRule: '',
+      body: '',
+      ...extra,
+    });
+
+    async function seedAndUpdate(
+      caldavUID: string,
+      rawVTODO: string,
+      task: CommonTask,
+      type: 'update' | 'complete' = 'update',
+    ): Promise<ICAL.Component> {
+      const client = makeClient();
+      const adapter = new CalDAVAdapter(client);
+      await client.connect();
+      await client.createVTODO(rawVTODO, caldavUID);
+
+      const idMapping: IdMapping = {
+        taskIdToCaldavUid: { [task.uid]: caldavUID },
+        caldavUidToTaskId: { [caldavUID]: task.uid },
+      };
+      await adapter.applyChanges([{ type, task }], idMapping);
+
+      const fetched = await client.fetchVTODOByUID(caldavUID);
+      const root = new ICAL.Component(ICAL.parse(fetched!.data) as unknown[]);
+      return root.name === 'vtodo' ? root : root.getFirstSubcomponent('vtodo')!;
+    }
+
+    it('preserves VALARM, RELATED-TO, X-* and an in-progress PERCENT-COMPLETE on an open update', async () => {
+      const uid = `e2e-foreign-${Date.now()}`;
+      const raw = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//jtx Board//EN',
+        'BEGIN:VTODO',
+        `UID:${uid}`,
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:Original title',
+        'STATUS:IN-PROCESS',
+        'PERCENT-COMPLETE:42',
+        'RELATED-TO;RELTYPE=PARENT:parent-task-uid',
+        'X-JTX-BOARD-COLOR:#ff0000',
+        'BEGIN:VALARM',
+        'TRIGGER:-PT15M',
+        'ACTION:DISPLAY',
+        'DESCRIPTION:Reminder text',
+        'END:VALARM',
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      const vtodo = await seedAndUpdate(uid, raw, openTask('obs-foreign', 'Edited title'));
+
+      expect(vtodo.getFirstPropertyValue('summary')).toBe('Edited title');
+      expect(vtodo.getFirstPropertyValue('status')).toBe('IN-PROCESS');
+      expect(vtodo.getFirstPropertyValue('percent-complete')).toBe(42);
+      expect(vtodo.getFirstPropertyValue('related-to')).toBe('parent-task-uid');
+      expect(vtodo.getFirstPropertyValue('x-jtx-board-color')).toBe('#ff0000');
+      const valarm = vtodo.getFirstSubcomponent('valarm');
+      expect(valarm).not.toBeNull();
+      expect(valarm!.getFirstPropertyValue('description')).toBe('Reminder text');
+    });
+
+    it('overrides STATUS to COMPLETED and forces PERCENT-COMPLETE to 100 on completion', async () => {
+      const uid = `e2e-foreign-done-${Date.now()}`;
+      const raw = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'BEGIN:VTODO',
+        `UID:${uid}`,
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:In progress task',
+        'STATUS:IN-PROCESS',
+        'PERCENT-COMPLETE:42',
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      const task = openTask('obs-foreign-done', 'In progress task', {
+        status: 'DONE',
+        completedDate: '2026-03-01',
+      });
+      const vtodo = await seedAndUpdate(uid, raw, task, 'complete');
+
+      expect(vtodo.getFirstPropertyValue('status')).toBe('COMPLETED');
+      expect(vtodo.getFirstPropertyValue('percent-complete')).toBe(100);
+      expect(vtodo.getFirstPropertyValue('completed')).not.toBeNull();
+    });
+
+    // F1 from PR #140: a document-wide DTSTART regex matched a VTIMEZONE rule's
+    // DTSTART. The component-scoped read makes that impossible even after the
+    // server stores and returns the object.
+    it('F1: keeps DTSTART TZID and time-of-day when rescheduling with a VTIMEZONE present', async () => {
+      const uid = `e2e-f1-tzid-${Date.now()}`;
+      const raw = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//DAVx5//EN',
+        'BEGIN:VTIMEZONE',
+        'TZID:Europe/Berlin',
+        'BEGIN:DAYLIGHT',
+        'DTSTART:19700329T020000',
+        'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3',
+        'TZOFFSETFROM:+0100',
+        'TZOFFSETTO:+0200',
+        'END:DAYLIGHT',
+        'BEGIN:STANDARD',
+        'DTSTART:19701025T030000',
+        'RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10',
+        'TZOFFSETFROM:+0200',
+        'TZOFFSETTO:+0100',
+        'END:STANDARD',
+        'END:VTIMEZONE',
+        'BEGIN:VTODO',
+        `UID:${uid}`,
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:Scheduled task',
+        'STATUS:NEEDS-ACTION',
+        'DTSTART;TZID=Europe/Berlin:20260214T083000',
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      const task = openTask('obs-f1-tzid', 'Scheduled task', { scheduledDate: '2026-07-20' });
+      const vtodo = await seedAndUpdate(uid, raw, task);
+      const dtstart = vtodo.getFirstProperty('dtstart')!;
+      const value = dtstart.getFirstValue() as ICAL.Time;
+
+      expect(dtstart.getParameter('tzid')).toBe('Europe/Berlin');
+      expect(value.isDate).toBe(false);
+      expect(value.year).toBe(2026);
+      expect(value.month).toBe(7);
+      expect(value.day).toBe(20);
+      // Original 08:30 time-of-day, never the 02:00 VTIMEZONE rule time.
+      expect(value.hour).toBe(8);
+      expect(value.minute).toBe(30);
+    });
+
+    it('F1: keeps a UTC (Z) DUE time-of-day when rescheduling', async () => {
+      const uid = `e2e-f1-utc-${Date.now()}`;
+      const raw = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'BEGIN:VTODO',
+        `UID:${uid}`,
+        'DTSTAMP:20250101T000000Z',
+        'SUMMARY:Due task',
+        'STATUS:NEEDS-ACTION',
+        'DUE:20260215T093000Z',
+        'END:VTODO',
+        'END:VCALENDAR',
+      ].join('\r\n');
+
+      const task = openTask('obs-f1-utc', 'Due task', { dueDate: '2026-08-01' });
+      const vtodo = await seedAndUpdate(uid, raw, task);
+      const value = vtodo.getFirstProperty('due')!.getFirstValue() as ICAL.Time;
+
+      expect(value.isDate).toBe(false);
+      expect(value.zone).toBe(ICAL.Timezone.utcTimezone);
+      expect(value.year).toBe(2026);
+      expect(value.month).toBe(8);
+      expect(value.day).toBe(1);
+      expect(value.hour).toBe(9);
+      expect(value.minute).toBe(30);
     });
   });
 


### PR DESCRIPTION
## Phase 2 (stacked on #145 / `feat/ical-js-vtodo-mapper`)

Builds on the Phase 1 ical.js migration to add a **foreign-property round-trip write path** and the **correct STATUS semantic**. Base this PR on `feat/ical-js-vtodo-mapper` — the diff shown is Phase 2 only.

Closes #140.

### What Phase 2 adds

- **`taskToVTODO(task, uid, existingData?)`** — on the update/complete path it parses the untouched server VTODO with ical.js, mutates **only plugin-owned properties** on the `vtodo` subcomponent, and serializes with `comp.toString()`. Everything else — `VALARM`, `RELATED-TO`, `X-*`, `VTIMEZONE`, unknown properties — passes through verbatim and correctly folded. The create path (no `existingData`) is unchanged from Phase 1.
- **DUE / DTSTART precision preservation** — if the existing server property was a `DATE-TIME` (has time-of-day and/or TZID), the plugin keeps its time-of-day and TZID and updates only the calendar date; a `VALUE=DATE` stays date-only; removing the date removes the property. The existing property is read **off the VTODO component**, never a document-wide search.
- **PERCENT-COMPLETE** — left untouched while the task is open (e.g. jtx Board's in-progress %); stripped and set to `100` on completion.
- **Adapter plumbing** — `fromCommonTask(task, uid, existingData?)` forwards `existingData`; `applyChanges` passes the raw `existing.data` from `fetchVTODOByUID` on both the `update` and `complete` paths.

### Deliberate STATUS behavior change

- **Read:** `IN-PROCESS → TODO`. obsidian-tasks has no in-progress checkbox, so the old `IN-PROCESS → IN_PROGRESS` mapping created a permanent phantom diff that rewrote `NEEDS-ACTION` over the server's `IN-PROCESS` every sync.
- **Write (update):** an open task (`TODO`) never overwrites the server's STATUS, so `IN-PROCESS` / `NEEDS-ACTION` survive. Only terminal states are written: `DONE → COMPLETED`, `CANCELLED → CANCELLED`. The create path still writes `NEEDS-ACTION` for `TODO`.
- The now-unproducible `IN_PROGRESS` member is removed from the `TaskStatus` union and from `mapStatusToVTODO` (verified: `obsidianMapper.mapStatus` only returns `DONE | TODO`, and nothing else yields it after the read change).

### Why this strictly subsumes #140 (F1–F4 structurally impossible)

#140 spliced VTODO text with document-wide regexes. Operating on the ical.js component tree eliminates each of its four bugs by construction:

- **F1 — VTIMEZONE `DTSTART` collision:** the task's `DTSTART`/`DUE` are read via `vtodo.getFirstProperty(...)`, scoped to the VTODO component. A sibling `VTIMEZONE`'s STANDARD/DAYLIGHT `DTSTART` lives in a different sub-component and can never be matched. The corrupting document-wide regex cannot exist here.
- **F2 — unfolded foreign lines:** ical.js owns unfolding on parse and folding on serialize, so multi-line foreign properties are preserved and re-folded correctly — no manual line handling.
- **F3 — managed props emitted after VALARM:** properties and sub-components live in the component's typed model; `updatePropertyWithValue` / `removeAllProperties` edit properties in place regardless of `VALARM` position, and serialization always emits a valid ordering.
- **F4 — multi-VTODO objects:** we select the `vtodo` subcomponent explicitly and edit only it, instead of regex-matching across the whole object body.

### New fixtures (evidence, not faith)

Radicale is not jtx Board, so explicit fixtures prove the round-trip.

- **Unit (`vtodoMapper.test.ts`):** foreign-property pass-through (VALARM / RELATED-TO / X-*), PERCENT-COMPLETE preserved on open update and forced to 100 on completion, the full STATUS matrix (IN-PROCESS preserved on open edit, NEEDS-ACTION pass-through, COMPLETED/CANCELLED on terminal), the F1 VTIMEZONE+`DTSTART;TZID` case, UTC `Z` and `TZID` DUE forms, VALUE=DATE downgrade when the server value was already date-only, and DTSTART removal. Phase 1 tests asserting `IN_PROGRESS` were updated to the new TODO behavior with explanatory comments.
- **E2E (`caldavAdapter.e2e.test.ts`):** the same round-trips through a real Radicale server (create raw VTODO → `applyChanges` → fetch → assert), including the F1 VTIMEZONE case and a UTC `Z` DUE reschedule.

### Results

- `npm test` (unit + E2E, Docker up): **574 passed / 574**. `vtodoMapper.ts` coverage 98.6% lines / 94.6% branches (thresholds 80/70).
- `npx tsc -noEmit -skipLibCheck`: clean.
- `npm run lint`: clean.
- `npm run build`: succeeds; `main.js` ~190 KB (in line with Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
