### PR TITLE
refactor(caldav): parse WebDAV multistatus with DOMParser instead of regex

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,6 +10,10 @@ const shared = {
   moduleFileExtensions: ['ts', 'js', 'json'],
   transform: { '^.+\\.ts$': ['ts-jest', { diagnostics: false }] },
   moduleNameMapper: { '^obsidian$': '<rootDir>/__mocks__/obsidian.ts' },
+  // Electron provides `DOMParser` as a global in production; Node's default Jest
+  // environment does not. Shim it for both projects so code using the global
+  // `DOMParser` (WebDAV XML parsing) runs under test.
+  setupFiles: ['<rootDir>/test/setup/domparser.ts'],
 };
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"@wdio/local-runner": "^9.27.1",
 				"@wdio/mocha-framework": "^9.27.1",
 				"@wdio/spec-reporter": "^9.27.1",
+				"@xmldom/xmldom": "^0.9.10",
 				"esbuild": "0.28.1",
 				"eslint": "^9.39.2",
 				"eslint-plugin-obsidianmd": "^0.1.9",
@@ -3923,6 +3924,16 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@xmldom/xmldom": {
+			"version": "0.9.10",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+			"integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.6"
 			}
 		},
 		"node_modules/@zip.js/zip.js": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"@wdio/local-runner": "^9.27.1",
 		"@wdio/mocha-framework": "^9.27.1",
 		"@wdio/spec-reporter": "^9.27.1",
+		"@xmldom/xmldom": "^0.9.10",
 		"esbuild": "0.28.1",
 		"eslint": "^9.39.2",
 		"eslint-plugin-obsidianmd": "^0.1.9",

--- a/src/caldav/calDAVClientDirect.test.ts
+++ b/src/caldav/calDAVClientDirect.test.ts
@@ -150,6 +150,36 @@ END:VCALENDAR</c:calendar-data>
             expect(vtodos[0].etag).toBeUndefined();
         });
 
+        it('should skip a tombstone response with an empty/self-closing calendar-data (Vikunja post-delete)', () => {
+            // After a delete, Vikunja's REPORT returns a response for the gone
+            // resource carrying an empty <calendar-data/>. Its textContent is ''
+            // — present but not a VTODO — so it must not become a phantom object.
+            const response = `<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+    <D:response>
+        <D:href>/dav/projects/3/deleted.ics</D:href>
+        <D:propstat>
+            <D:prop>
+                <C:calendar-data/>
+            </D:prop>
+            <D:status>HTTP/1.1 404 Not Found</D:status>
+        </D:propstat>
+    </D:response>
+    <D:response>
+        <D:href>/dav/projects/3/live.ics</D:href>
+        <D:propstat>
+            <D:prop>
+                <C:calendar-data>BEGIN:VCALENDAR&#xA;BEGIN:VTODO&#xA;UID:live-1&#xA;END:VTODO&#xA;END:VCALENDAR</C:calendar-data>
+            </D:prop>
+        </D:propstat>
+    </D:response>
+</D:multistatus>`;
+
+            const vtodos = CalDAVClientDirect.parseVTODOsFromXML(response, 'http://localhost:3457');
+
+            expect(vtodos).toHaveLength(1);
+            expect(vtodos[0].data).toContain('UID:live-1');
+        });
+
         it('should decode XML entities in calendar-data (Vikunja format)', () => {
             const response = `<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
     <D:response>

--- a/src/caldav/calDAVClientDirect.test.ts
+++ b/src/caldav/calDAVClientDirect.test.ts
@@ -233,6 +233,42 @@ END:VCALENDAR</c:calendar-data>
             expect(vtodos[0].data).toContain('STATUS:IN-PROCESS');
             expect(vtodos[0].etag).toBe('etag-ox-1');
         });
+
+        it('should parse calendar-data with attributes on the opening tag (DavMail format)', () => {
+            const response = `<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+    <D:response>
+        <D:href>/users/user@example.com/calendar/davmail-1.ics</D:href>
+        <D:propstat>
+            <D:prop>
+                <D:getetag>"davmail-etag-1"</D:getetag>
+                <C:calendar-data xmlns:C="urn:ietf:params:xml:ns:caldav" C:content-type="text/calendar" C:version="2.0">BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//DavMail//EN
+BEGIN:VTODO
+UID:davmail-task-1
+SUMMARY:Review report
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR</C:calendar-data>
+            </D:prop>
+        </D:propstat>
+    </D:response>
+</D:multistatus>`;
+
+            const vtodos = CalDAVClientDirect.parseVTODOsFromXML(response, 'https://dav.example.com');
+
+            expect(vtodos).toHaveLength(1);
+            expect(vtodos[0].url).toBe('https://dav.example.com/users/user@example.com/calendar/davmail-1.ics');
+            expect(vtodos[0].data).toContain('UID:davmail-task-1');
+            expect(vtodos[0].data).toContain('SUMMARY:Review report');
+            expect(vtodos[0].data).not.toContain('content-type');
+            expect(vtodos[0].etag).toBe('davmail-etag-1');
+        });
+
+        it('should return an empty array for malformed XML instead of throwing', () => {
+            const vtodos = CalDAVClientDirect.parseVTODOsFromXML('<D:multistatus><D:response></broken>', 'https://dav.example.com');
+            expect(vtodos).toEqual([]);
+        });
     });
 
     describe('connect() and pinned fetch', () => {

--- a/src/caldav/calDAVClientDirect.ts
+++ b/src/caldav/calDAVClientDirect.ts
@@ -124,12 +124,16 @@ export class CalDAVClientDirect implements CalDAVClient {
       const response = responses[i];
 
       const href = firstChildText(response, 'href');
-      const calendarData = firstChildText(response, 'calendar-data');
-      if (href === undefined || calendarData === undefined) continue;
+      // Skip tombstone/error responses that carry an empty or self-closing
+      // <calendar-data/> (e.g. Vikunja's post-delete multistatus). Their
+      // textContent is '' — present but not a VTODO — so a bare presence check
+      // would emit a phantom object.
+      const calendarData = firstChildText(response, 'calendar-data')?.trim();
+      if (!href || !calendarData) continue;
 
       vtodos.push({
         url: resolveUrl(href, contextUrl),
-        data: calendarData.trim(),
+        data: calendarData,
         etag: stripQuotes(firstChildText(response, 'getetag')),
       });
     }

--- a/src/caldav/calDAVClientDirect.ts
+++ b/src/caldav/calDAVClientDirect.ts
@@ -104,36 +104,34 @@ export class CalDAVClientDirect implements CalDAVClient {
   }
 
   /**
-   * Parse VTODOs from calendar-query XML response (static for testing)
+   * Parse VTODOs from a WebDAV multistatus (calendar-query) XML response.
+   *
+   * Uses the platform `DOMParser` (native in Electron; shimmed in Node tests),
+   * so namespaces, CDATA, and XML entities are decoded by the parser itself
+   * rather than by hand-rolled regex. Element lookup is namespace-prefix-agnostic
+   * (`d:`/`D:`/`c:`/`C:`/none) via `getElementsByTagNameNS('*', …)`. A response
+   * missing an `href` or `calendar-data` is skipped, and malformed XML yields an
+   * empty result instead of throwing. Static for testing.
    */
   static parseVTODOsFromXML(xmlText: string, contextUrl: string): CalendarObject[] {
+    const doc = parseXmlDocument(xmlText);
+    if (!doc) return [];
+
     const vtodos: CalendarObject[] = [];
-    const responseRegex = /<(?:\w+:)?response>([\s\S]*?)<\/(?:\w+:)?response>/g;
-    let match;
+    const responses = doc.getElementsByTagNameNS('*', 'response');
 
-    while ((match = responseRegex.exec(xmlText)) !== null) {
-      const responseBlock = match[1];
+    for (let i = 0; i < responses.length; i++) {
+      const response = responses[i];
 
-      // Extract href (any namespace prefix or none)
-      const hrefMatch = responseBlock.match(/<(?:\w+:)?href>([^<]+)<\/(?:\w+:)?href>/);
-      if (!hrefMatch) continue;
+      const href = firstChildText(response, 'href');
+      const calendarData = firstChildText(response, 'calendar-data');
+      if (href === undefined || calendarData === undefined) continue;
 
-      const url = resolveUrl(hrefMatch[1], contextUrl);
-
-      // Extract etag (any namespace prefix or none)
-      // Nextcloud returns ETags with XML-encoded quotes: &quot;abc123&quot;
-      const etagMatch = responseBlock.match(/<(?:\w+:)?getetag>([^<]+)<\/(?:\w+:)?getetag>/);
-      const etag = etagMatch
-        ? etagMatch[1].replace(/&quot;/g, '').replace(/"/g, '')
-        : undefined;
-
-      // Extract calendar data (VTODO) — handle optional CDATA wrapping, any namespace prefix
-      const dataMatch = responseBlock.match(/<(?:\w+:)?calendar-data(?:\s[^>]*)?>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/(?:\w+:)?calendar-data>/);
-      if (!dataMatch) continue;
-
-      const data = decodeXMLEntities(dataMatch[1].trim());
-
-      vtodos.push({ data, url, etag });
+      vtodos.push({
+        url: resolveUrl(href, contextUrl),
+        data: calendarData.trim(),
+        etag: stripQuotes(firstChildText(response, 'getetag')),
+      });
     }
 
     return vtodos;
@@ -294,16 +292,35 @@ export class CalDAVClientDirect implements CalDAVClient {
 }
 
 /**
- * Decode XML character entities in calendar-data.
- * Some servers (e.g. Vikunja) return iCal data with XML-escaped newlines
- * (&#xA;) instead of actual newlines or CDATA wrapping.
+ * Parse a WebDAV XML payload into a document, returning null on any failure.
+ * `DOMParser` implementations diverge on malformed input: Electron's native
+ * parser returns a document containing a `<parsererror>` element, while
+ * `@xmldom/xmldom` (used in tests) throws. Handle both so a bad response never
+ * propagates an exception — matching the previous regex parser's resilience.
  */
-function decodeXMLEntities(text: string): string {
-  return text
-    .replace(/&#xA;/g, '\n')
-    .replace(/&#xD;/g, '\r')
-    .replace(/&#x9;/g, '\t')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&');
+function parseXmlDocument(xmlText: string): Document | null {
+  try {
+    const doc = new DOMParser().parseFromString(xmlText, 'application/xml');
+    if (doc.getElementsByTagNameNS('*', 'parsererror').length > 0) return null;
+    return doc;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Text content of the first descendant element with the given local name,
+ * across any namespace prefix. Returns undefined when absent.
+ */
+function firstChildText(element: Element, localName: string): string | undefined {
+  const match = element.getElementsByTagNameNS('*', localName)[0];
+  return match ? match.textContent ?? undefined : undefined;
+}
+
+/**
+ * Strip surrounding quotes from an etag value. Nextcloud XML-encodes them as
+ * `&quot;` (decoded to `"` by the parser); other servers use literal quotes.
+ */
+function stripQuotes(value: string | undefined): string | undefined {
+  return value?.replace(/"/g, '');
 }

--- a/test/setup/domparser.ts
+++ b/test/setup/domparser.ts
@@ -1,0 +1,8 @@
+// Obsidian runs in Electron, where `DOMParser` is a browser global. Jest runs
+// in Node's default environment, which has no `DOMParser`, so shipped code that
+// relies on the global would fail under test. Inject a spec-compliant XML
+// `DOMParser` (from @xmldom/xmldom, a devDependency) as the global for tests.
+// Production ships zero XML dependency and uses Electron's native `DOMParser`.
+import { DOMParser } from '@xmldom/xmldom';
+
+(globalThis as unknown as { DOMParser: typeof DOMParser }).DOMParser = DOMParser;


### PR DESCRIPTION
## What & why

Replaces the hand-rolled regex in `CalDAVClientDirect.parseVTODOsFromXML` — which pulled `href`, `getetag`, and `calendar-data` out of a WebDAV multistatus response with regexes — with a real XML parse via the platform `DOMParser`. This is WebDAV XML, not iCalendar, so ical.js does not apply.

This **kills the last regex-based parser** in the client. `DOMParser` handles what the regex struggled with, natively:
- **Namespaces** — any prefix (`d:`/`D:`/`c:`/`C:`/none) via `getElementsByTagNameNS('*', …)`.
- **CDATA + XML entities** — unwrapped/decoded by the parser, so the hand-rolled `decodeXMLEntities` (Vikunja `&#xA;`, `&lt;`/`&amp;`, etc.) is deleted.
- **Attributes on the opening tag** — e.g. DavMail's `<C:calendar-data xmlns:C="…" C:content-type="text/calendar" C:version="2.0">…`. The regex needed a special case for this; `DOMParser` does not.

Resilience is preserved: a `response` missing `href` or `calendar-data` is skipped, etag quotes are stripped, hrefs resolve against `contextUrl`, and malformed XML returns `[]` instead of throwing. Scope is limited to `parseVTODOsFromXML` and its helpers — `createVTODO`'s HTTP-200 handling and every other method are untouched, and the method signature is identical so all callers are unchanged.

## Relationship to #143

This makes #143's **regex fix-1** (patching the attribute case with `[^>]*`) unnecessary — `DOMParser` parses that natively, so there's no regex left to patch. #143's **HTTP-200 acceptance fix in `createVTODO`** is independent and stays as-is; nothing here touches it.

## Option A vs B

Landed on **Option A** (native `DOMParser`, zero runtime dependency). Obsidian runs in Electron where `DOMParser` is a global, so shipped code adds no XML library. `@xmldom/xmldom` is a **devDependency**, shimmed as a global for Node/Jest in `test/setup/domparser.ts` and wired into both jest projects with a single `setupFiles` line — small, simple plumbing. The one DOM-API divergence (native returns a `<parsererror>` document; `@xmldom/xmldom` throws) is absorbed by a single defensive helper that handles both, so no behavior-specific branching leaked in. Option A stayed simple, so no need for Option B.

**Bundle impact:** none. `main.js` = 195,870 bytes (192K), and `grep xmldom main.js` = 0 — the XML lib is not in the shipped bundle.

## Tests / build

- All existing `parseVTODOsFromXML` unit tests pass unchanged (namespaces, CDATA, quote-stripping, Vikunja/Open-Xchange formats).
- Added a **DavMail attribute-on-opening-tag** test (demonstrates #143's regex fix-1 is subsumed) and a **malformed-XML → `[]`** test.
- `npm run test:unit` — 23 suites, **542 passed**. `src/caldav` coverage 84.9% lines / 76.5% branches (thresholds 80/70).
- Radicale core E2E (real client → new parser round-trips) — 26 suites, **575 passed**.
- `npx tsc -noEmit -skipLibCheck` clean; `npm run lint` clean; `npm run build` succeeds.
- Full `npm test`: 584 passed. The only 3 failures are Vikunja E2E `beforeAll` **hook timeouts** ("cleanup is not a function" / connect timeout) caused by a shared Vikunja container held by a parallel worktree on this machine — they never reach the parser (they die in `connect()`), and Radicale E2E exercising the exact same code path is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
