### PR TITLE
fix(sync): reconcile unmapped tasks against existing server tasks instead of duplicating

### DIFF
--- a/src/sync/diff.test.ts
+++ b/src/sync/diff.test.ts
@@ -480,6 +480,61 @@ describe('diff', () => {
       expect(result.toObsidian.filter(c => c.type === 'reconcile')).toHaveLength(1);
       expect(result.toCalDAV.filter(c => c.type === 'reconcile')).toHaveLength(1);
     });
+
+    it('should reconcile an unmapped vault task against a baselined CalDAV task instead of creating a duplicate', () => {
+      // The id-mapping drifted: the vault task carries a new, unmapped id
+      // ('obs-drifted'), while its content-identical CalDAV counterpart is
+      // still in the baseline mapped to a now-absent Obsidian id ('obs-gone').
+      const obsTask = makeCommonTask({ uid: 'obs-drifted', title: 'Buy milk' });
+      const calTask = makeCommonTask({ uid: 'obs-gone', caldavId: 'caldav-uid-1', title: 'Buy milk' });
+      const baseline = makeCommonTask({ uid: 'obs-gone', title: 'Buy milk' });
+
+      const result = diff([obsTask], [calTask], [baseline], 'caldav-wins');
+
+      // No duplicate is created on either side; instead both sides reconcile.
+      expect(result.toCalDAV.filter(c => c.type === 'create')).toHaveLength(0);
+      expect(result.toObsidian.filter(c => c.type === 'create')).toHaveLength(0);
+      expect(result.toCalDAV.filter(c => c.type === 'delete')).toHaveLength(0);
+
+      const obsReconciles = result.toObsidian.filter(c => c.type === 'reconcile');
+      const calReconciles = result.toCalDAV.filter(c => c.type === 'reconcile');
+      expect(obsReconciles).toHaveLength(1);
+      expect(obsReconciles[0].task.uid).toBe('obs-drifted');
+      // The mapping must link to the real CalDAV server UID, not the stale key.
+      expect(obsReconciles[0].counterpartUid).toBe('caldav-uid-1');
+      expect(calReconciles).toHaveLength(1);
+      expect(calReconciles[0].counterpartUid).toBe('obs-drifted');
+    });
+
+    it('should not amplify: unmapped vault task + N identical baselined server tasks yields zero CalDAV creates', () => {
+      const obsTask = makeCommonTask({ uid: 'obs-drifted', title: 'Recurring dupe' });
+      const calTasks = Array.from({ length: 5 }, (_, i) =>
+        makeCommonTask({ uid: `obs-gone-${i}`, caldavId: `caldav-uid-${i}`, title: 'Recurring dupe' }),
+      );
+      const baseline = calTasks.map(c => makeCommonTask({ uid: c.uid, title: 'Recurring dupe' }));
+
+      const result = diff([obsTask], calTasks, baseline, 'caldav-wins');
+
+      // The vault task must never spawn a new CalDAV copy...
+      expect(result.toCalDAV.filter(c => c.type === 'create')).toHaveLength(0);
+      // ...nor pull the surplus copies back into the vault (the other half of
+      // the amplifying loop). Exactly one pair reconciles.
+      expect(result.toObsidian.filter(c => c.type === 'create')).toHaveLength(0);
+      expect(result.toObsidian.filter(c => c.type === 'reconcile')).toHaveLength(1);
+      expect(result.toCalDAV.filter(c => c.type === 'reconcile')).toHaveLength(1);
+    });
+
+    it('should still create a genuinely new vault task when no content-equal CalDAV task exists', () => {
+      const obsTask = makeCommonTask({ uid: 'obs-new', title: 'Truly new' });
+      const calTask = makeCommonTask({ uid: 'obs-gone', caldavId: 'caldav-uid-1', title: 'Unrelated' });
+      const baseline = makeCommonTask({ uid: 'obs-gone', title: 'Unrelated' });
+
+      const result = diff([obsTask], [calTask], [baseline], 'caldav-wins');
+
+      expect(result.toCalDAV.filter(c => c.type === 'create')).toHaveLength(1);
+      expect(result.toCalDAV.filter(c => c.type === 'create')[0].task.uid).toBe('obs-new');
+      expect(result.toObsidian.filter(c => c.type === 'reconcile')).toHaveLength(0);
+    });
   });
 
   describe('completion detection', () => {

--- a/src/sync/diff.ts
+++ b/src/sync/diff.ts
@@ -164,9 +164,20 @@ function reconcileOrphans(
     }
   }
 
+  // A CalDAV task is eligible for reconciliation whenever no *live* Obsidian
+  // task is currently paired with it (its map key is absent from the vault).
+  // We intentionally do NOT exclude tasks that are present in the baseline: the
+  // amplifying-duplication bug happens precisely when the vault's task IDs drift
+  // out of the id-mapping (interrupted sync, backup restore, multi-device), so
+  // the CalDAV counterpart still sits in the baseline mapped to an Obsidian ID
+  // that no longer exists. Excluding baselined tasks would leave the unmapped
+  // vault task nothing to reconcile against, and it would create a duplicate on
+  // CalDAV (which then gets pulled back, re-duplicated, and amplifies). Keeping
+  // the `!obsidianByUid.has(uid)` guard is what prevents a mis-merge: a CalDAV
+  // task a live vault task owns is never up for grabs.
   const calOrphanPool = new Map<string, CommonTask>();
   for (const [uid, task] of caldavByUid) {
-    if (!obsidianByUid.has(uid) && !baselineByUid.has(uid)) {
+    if (!obsidianByUid.has(uid)) {
       calOrphanPool.set(uid, task);
     }
   }
@@ -174,7 +185,12 @@ function reconcileOrphans(
   for (const obsTask of obsOrphans) {
     for (const [calUid, calTask] of calOrphanPool) {
       if (tasksEqual(obsTask, calTask)) {
-        toObsidian.push({ type: 'reconcile', task: obsTask, counterpartUid: calUid });
+        // Link the mapping to the real CalDAV server identity (`caldavId`), not
+        // the pool key: a baselined orphan is keyed by its stale mapped Obsidian
+        // ID, which is not a server UID. Fall back to the key for unmapped
+        // orphans whose fixtures carry no `caldavId`, keeping behavior unchanged.
+        const calServerUid = calTask.caldavId ?? calUid;
+        toObsidian.push({ type: 'reconcile', task: obsTask, counterpartUid: calServerUid });
         toCalDAV.push({ type: 'reconcile', task: calTask, counterpartUid: obsTask.uid });
         reconciledUids.add(obsTask.uid);
         reconciledUids.add(calUid);

--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -461,6 +461,99 @@ describe('SyncEngine', () => {
       expect(mockDeleteVTODOByUID).toHaveBeenCalledTimes(1);
       expect(mockSetIdMapping).toHaveBeenCalled();
     });
+
+    it('heals an unmapped vault-originated task instead of writing an empty-uid baseline phantom', async () => {
+      // A vault-originated task (Obsidian id == CalDAV uid) whose id-mapping was
+      // lost: normalize() gives it uid:'' but caldavId equals the vault id, so
+      // diff() matches the pair as an unchanged no-op that no changeset touches.
+      const stableId = '20260416-843';
+      const title = 'Project docs';
+      const obsTask = makeObsidianTask({ description: title, id: stableId, tags: [] });
+      mockGetAllTasksWithBody.mockResolvedValue(withBody(obsTask));
+      mockFetchVTODOs.mockResolvedValue([makeCalObj(stableId, title)]);
+      mockGetIdMapping.mockReturnValue({ taskIdToCaldavUid: {}, caldavUidToTaskId: {} }); // mapping lost
+      mockGetBaseline.mockReturnValue([{
+        uid: stableId,
+        title,
+        status: 'TODO',
+        dueDate: null,
+        startDate: null,
+        scheduledDate: null,
+        completedDate: null,
+        priority: 'none',
+        tags: [],
+        recurrenceRule: '',
+        body: '',
+      }]);
+
+      const engine = new SyncEngine(new App(), makeCalendarMapping(), makeSettings());
+      await engine.initialize();
+      const result = await engine.sync();
+
+      // Pure no-op: nothing created/updated/deleted/reconciled on either side.
+      expect(result.created).toEqual({ toObsidian: 0, toCalDAV: 0 });
+      expect(result.updated).toEqual({ toObsidian: 0, toCalDAV: 0 });
+      expect(result.deleted).toEqual({ toObsidian: 0, toCalDAV: 0 });
+      expect(result.reconciled).toBe(0);
+      expect(mockCreateVTODO).not.toHaveBeenCalled();
+      expect(mockCreateTask).not.toHaveBeenCalled();
+
+      // Baseline: exactly one entry keyed by the real uid, no '' phantom, and no
+      // caldavId leaked into the persisted snapshot.
+      const baselineCall = mockSetBaseline.mock.calls.at(-1) as [Array<Record<string, unknown>>] | undefined;
+      const persistedBaseline = baselineCall?.[0] ?? [];
+      expect(persistedBaseline).toHaveLength(1);
+      expect(persistedBaseline[0].uid).toBe(stableId);
+      expect(persistedBaseline.some((t) => t.uid === '')).toBe(false);
+      expect(persistedBaseline.every((t) => !('caldavId' in t))).toBe(true);
+
+      // Self-heal: the mapping is restored so subsequent syncs stay consistent.
+      const mappingCall = mockSetIdMapping.mock.calls.at(-1) as [IdMapping] | undefined;
+      const persistedMapping = mappingCall?.[0] as IdMapping;
+      expect(persistedMapping.taskIdToCaldavUid[stableId]).toBe(stableId);
+      expect(persistedMapping.caldavUidToTaskId[stableId]).toBe(stableId);
+    });
+
+    it('is idempotent after healing an unmapped vault-originated task', async () => {
+      const stableId = '20260416-843';
+      const title = 'Project docs';
+      const obsTask = makeObsidianTask({ description: title, id: stableId, tags: [] });
+      mockGetAllTasksWithBody.mockResolvedValue(withBody(obsTask));
+      mockFetchVTODOs.mockResolvedValue([makeCalObj(stableId, title)]);
+
+      // Second sync starts from the healed state produced by the first.
+      mockGetIdMapping.mockReturnValue({
+        taskIdToCaldavUid: { [stableId]: stableId },
+        caldavUidToTaskId: { [stableId]: stableId },
+      });
+      mockGetBaseline.mockReturnValue([{
+        uid: stableId,
+        title,
+        status: 'TODO',
+        dueDate: null,
+        startDate: null,
+        scheduledDate: null,
+        completedDate: null,
+        priority: 'none',
+        tags: [],
+        recurrenceRule: '',
+        body: '',
+      }]);
+
+      const engine = new SyncEngine(new App(), makeCalendarMapping(), makeSettings());
+      await engine.initialize();
+      const result = await engine.sync();
+
+      expect(result.created).toEqual({ toObsidian: 0, toCalDAV: 0 });
+      expect(result.updated).toEqual({ toObsidian: 0, toCalDAV: 0 });
+      expect(result.deleted).toEqual({ toObsidian: 0, toCalDAV: 0 });
+      expect(mockCreateVTODO).not.toHaveBeenCalled();
+      expect(mockDeleteVTODOByUID).not.toHaveBeenCalled();
+      const baselineCall = mockSetBaseline.mock.calls.at(-1) as [Array<Record<string, unknown>>] | undefined;
+      const persistedBaseline = baselineCall?.[0] ?? [];
+      expect(persistedBaseline).toHaveLength(1);
+      expect(persistedBaseline.every((t) => !('caldavId' in t))).toBe(true);
+    });
   });
 
   describe('result counting', () => {

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -93,6 +93,7 @@ export class SyncEngine {
 			if (dryRun) return this.buildResult(applicable, obsidianTasks, caldavTasks, baseline, true, showProgress);
 
 			this.completePulledIdentities(applicable, idMapping);
+			this.healUnmappedVaultMatches(caldavTasks, obsidianTasks, idMapping);
 
 			const progress: SyncProgress = {
 				pullDone: 0,
@@ -226,6 +227,32 @@ export class SyncEngine {
 		}
 	}
 
+	/**
+	 * Heal a vault-originated task whose id-mapping was lost. `normalize()` leaves
+	 * it with `uid: ""` (unmapped), but its CalDAV `caldavId` equals the vault
+	 * task's own id, so `diff()` still matches the pair in the main loop via the
+	 * `uid || caldavId` join — as an unchanged no-op that no changeset touches.
+	 * Left alone, that CalDAV CommonTask keeps `uid: ""` and lands in the baseline
+	 * as an empty-uid phantom (and drags its derived `caldavId` onto disk). Stamp
+	 * the stable identity back on and restore the mapping so the pair self-heals
+	 * rather than duplicating on the next sync.
+	 */
+	private healUnmappedVaultMatches(
+		caldavTasks: CommonTask[],
+		obsidianTasks: CommonTask[],
+		idMapping: IdMapping,
+	): void {
+		const obsidianUids = new Set(obsidianTasks.map((t) => t.uid));
+		for (const task of caldavTasks) {
+			if (task.uid !== "") continue;
+			const caldavUid = task.caldavId ?? "";
+			if (!caldavUid || !obsidianUids.has(caldavUid)) continue;
+			task.uid = caldavUid;
+			idMapping.taskIdToCaldavUid[caldavUid] = caldavUid;
+			idMapping.caldavUidToTaskId[caldavUid] = caldavUid;
+		}
+	}
+
 	private mintTaskIdForCaldav(task: CommonTask, idMapping: IdMapping): string {
 		const caldavUid = task.caldavId ?? "";
 		const taskId = this.obsidianAdapter.reserveTaskId();
@@ -303,6 +330,11 @@ export class SyncEngine {
 			baselineMap.set(task.uid, task);
 		}
 		for (const task of caldavTasks) {
+			// An unmapped CalDAV task has no stable Obsidian identity to persist;
+			// keying the baseline by "" would write a phantom duplicate. Matched
+			// tasks were already stamped by healUnmappedVaultMatches; anything
+			// still empty here (e.g. a mapping-less delete) must not be persisted.
+			if (task.uid === "") continue;
 			if (!baselineMap.has(task.uid)) {
 				baselineMap.set(task.uid, task);
 			}
@@ -323,7 +355,19 @@ export class SyncEngine {
 			}
 		}
 
-		return Array.from(baselineMap.values());
+		return Array.from(baselineMap.values()).map((task) => this.forBaseline(task));
+	}
+
+	/**
+	 * Strip fields that are derived per fetch and must never reach `baseline.json`.
+	 * `caldavId` is re-derived by caldavAdapter.normalize() on every sync, so a
+	 * persisted copy is both dead weight and a leak of server identity.
+	 */
+	private forBaseline(task: CommonTask): CommonTask {
+		if (task.caldavId === undefined) return task;
+		const copy = { ...task };
+		delete copy.caldavId;
+		return copy;
 	}
 
 	private buildResult(

--- a/test/wdio/specs/reconcileUnmapped.e2e.ts
+++ b/test/wdio/specs/reconcileUnmapped.e2e.ts
@@ -1,0 +1,84 @@
+import { browser } from '@wdio/globals';
+import { createIsolatedCalendar } from '../../helpers/radicaleSetup';
+import { useCalendarUrl, waitForTaskInCache, syncNow } from '../helpers/pluginConfig';
+import { fetchVtodos, countVtodos } from '../helpers/calendarQuery';
+import { appendTaskLine, replaceInFile } from '../helpers/vaultEdit';
+
+/**
+ * Regression for the amplifying-duplication loop (unmapped vault task).
+ *
+ * When a vault task's id drifts out of the id-mapping (interrupted sync, backup
+ * restore, multi-device), its content-identical CalDAV counterpart is still in
+ * the baseline mapped to the now-absent old id. Before the fix, `reconcileOrphans`
+ * excluded baselined CalDAV tasks from the reconcile pool, so the unmapped vault
+ * task had nothing to pair with and the diff emitted a CalDAV `create` (a fresh
+ * server duplicate) plus a `delete` of the original — churning the server object
+ * identity and disabling the de-duplication net exactly when divergence occurs.
+ * The fix reconciles the drifted vault task to the existing server VTODO instead.
+ *
+ * We drift the id in the markdown (leaving mapping + baseline pinned to the old
+ * id) to recreate the exact precondition, then re-sync. The decisive assertion is
+ * that the server VTODO's UID is PRESERVED across the re-sync: reconcile leaves it
+ * untouched, whereas the pre-fix delete+create replaces it with a new UID. The
+ * count staying at 1 guards the visible duplicate.
+ */
+describe('reconcile unmapped vault task', function () {
+  let calendarName: string;
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeEach(async function () {
+    const cal = await createIsolatedCalendar();
+    calendarName = cal.calendarName;
+    cleanup = cal.cleanup;
+    await useCalendarUrl(calendarName);
+  });
+
+  afterEach(async function () { await cleanup?.(); });
+
+  function uidOf(ical: string): string {
+    const unfolded = ical.replace(/\r?\n[ \t]/g, '');
+    const match = unfolded.match(/^UID:(.+)$/m);
+    if (!match) throw new Error(`could not parse UID from server response:\n${ical}`);
+    return match[1].trim();
+  }
+
+  async function taskIdInCache(title: string): Promise<string | undefined> {
+    return await browser.executeObsidian(({ app }, t) => {
+      const tp = (app as any).plugins.plugins['obsidian-tasks-plugin'];
+      const task = tp.getTasks().find((x: any) => x.description.includes(t));
+      return task?.id as string | undefined;
+    }, title);
+  }
+
+  it('reconciles a drifted-id vault task to the existing server VTODO instead of duplicating', async function () {
+    const title = `Buy milk ${Date.now()}`;
+
+    // Phase 1: create in Obsidian, sync, and confirm one server VTODO exists.
+    await appendTaskLine('Tasks.md', `- [ ] ${title} #sync`);
+    await waitForTaskInCache(title);
+    await syncNow();
+    await browser.waitUntil(async () => (await fetchVtodos(calendarName)).includes(title),
+      { timeout: 15000, interval: 500, timeoutMsg: `"${title}" never reached the server` });
+
+    const originalId = await taskIdInCache(title);
+    if (!originalId) throw new Error('task never received a stable id after first sync');
+    const originalUid = uidOf(await fetchVtodos(calendarName));
+
+    // Phase 2: drift the vault task's id out of the id-mapping. Mapping and
+    // baseline stay pinned to `originalId`; the vault now carries `driftedId`.
+    const driftedId = `${originalId.replace(/-.*$/, '')}-dead`;
+    await replaceInFile('Tasks.md', `🆔 ${originalId}`, `🆔 ${driftedId}`);
+    await browser.waitUntil(async () => (await taskIdInCache(title)) === driftedId,
+      { timeout: 20000, interval: 500, timeoutMsg: 'obsidian-tasks never re-indexed the drifted id' });
+
+    // Phase 3: re-sync. The unmapped vault task must reconcile to the existing
+    // VTODO, not spawn a duplicate.
+    await syncNow();
+
+    const ical = await fetchVtodos(calendarName);
+    expect(countVtodos(ical)).toBe(1);
+    // The surviving VTODO must be the ORIGINAL one (reconcile), not a recreated
+    // copy under a new UID (the pre-fix delete+create behavior).
+    expect(uidOf(ical)).toBe(originalUid);
+  });
+});


### PR DESCRIPTION
## The amplifying-duplication loop

A real user hit an amplifying loop after their vault task ids drifted out of the persisted id-mapping (73 of 76 `#sync` tasks had ids that were **not** in `id-mapping.json` — from interrupted syncs, backup restore, or multi-device). One test task reached **1386 server copies**.

The loop has two halves that feed each other:
1. An **unmapped vault task** (its id isn't in the mapping) finds no CalDAV counterpart by uid → the diff **creates it on CalDAV as new**, duplicating one that already exists.
2. Bidirectional + caldav-wins also **pulls** unmatched server tasks back into the vault, where they get fresh unmapped ids → step 1 pushes them back → amplification.

## Root cause 1 — the reconcile net was disabled exactly when divergence occurs

`reconcileOrphans` in `src/sync/diff.ts` is the safety net that pairs an unmapped Obsidian orphan with a content-identical CalDAV task instead of duplicating. Its CalDAV orphan pool excluded **any** task present in the baseline:

```ts
if (!obsidianByUid.has(uid) && !baselineByUid.has(uid)) calOrphanPool.set(uid, task);
```

But the drifted task's CalDAV counterpart is almost always **in the baseline** (it synced before; only the Obsidian side lost its mapping). So the pool was empty and the unmapped vault task had nothing to reconcile against → it duplicated.

### Fix
Admit a baselined CalDAV task into the pool as long as **no live vault task owns it** (`!obsidianByUid.has(uid)`) — that guard is what prevents a mis-merge (a task a live vault entry owns is never up for grabs). The reconcile links the mapping to the **real CalDAV server UID** (`caldavId`), not the stale map key. Because `reconcileOrphans` pairs both sides and adds both uids to `reconciledUids` (removed from the main loop), fixing the pairing once fixes **both** halves: the paired vault task no longer creates on CalDAV, and the paired server task is no longer pulled into the vault.

### Why it's safe
- **No mis-merge:** a CalDAV task currently paired with a live vault task is excluded from the pool.
- **No broken creates:** reconcile only fires on a content-identical (`tasksEqual`) match; a genuinely new vault task with no content-equal CalDAV task still creates.
- **No amplification:** with N identical baselined server tasks, the vault task reconciles to one and the surplus is handled as ordinary deletes — **zero** CalDAV creates, no pull-back.
- **Legitimate deletion preserved:** an intentionally deleted vault task has no content-identical unmapped orphan, so its deletion still propagates.

## Root cause 2 — `completePulledIdentities` coverage gap → empty-uid baseline phantom

Same class (unmapped tasks in the #144 `caldavId` model), found in real user data. A vault-originated task (Obsidian id == CalDAV uid, e.g. `20260416-843`) whose mapping was lost gets `uid: ""` from `normalize()`, but still **matches** its vault task in the main diff loop via the `caldavKey = uid || caldavId` join — as an unchanged `obs && cal && base` no-op that no changeset touches. `completePulledIdentities` only stamps uids on toObsidian creates/reconciles, so it never fixed this task. Its CalDAV CommonTask kept `uid: ""` and `computeNewBaseline` wrote it as a **second, empty-keyed baseline entry** (a phantom duplicate), dragging its derived `caldavId` into `baseline.json`.

### Fix
- `healUnmappedVaultMatches` stamps the stable Obsidian id back onto a matched-via-`caldavId` CalDAV task and restores the mapping, so the pair self-heals instead of duplicating next sync.
- `computeNewBaseline` never persists an `uid === ""` entry (belt-and-suspenders for the mapping-less delete case) and strips the derived `caldavId` from every baseline entry (it is re-derived per fetch and must never be stored).

## Reproduction & tests

**Diff-level (Jest)** — failed pre-fix, pass post-fix:
- unmapped vault task + content-identical baselined CalDAV task ⇒ **reconcile, not create** (mapping links to the real server UID).
- unmapped vault task + N identical baselined server tasks ⇒ **zero CalDAV creates** (amplification guard).
- genuinely new vault task with no content-equal CalDAV task ⇒ still creates (regression guard).

**Baseline-level (Jest, syncEngine)** — the "heals" test fails pre-fix:
- vault-originated task with lost mapping ⇒ exactly **one** baseline entry keyed by the real uid, **no** empty-uid phantom, **no** `caldavId` persisted, mapping self-healed, and a second sync produces **zero** changes (idempotent).

**Real-Obsidian (wdio, `test/wdio/specs/reconcileUnmapped.e2e.ts`)** — passes post-fix, fails pre-fix:
- Create a `#sync` task, sync (1 server VTODO), drift the vault task's `🆔` out of the mapping, sync again. The server still has **exactly 1** VTODO **and its UID is preserved** — proving reconcile, not delete+recreate. Pre-fix the UID changes (delete+create), which the spec catches.

## Results
- New Jest repro tests fail pre-fix, pass post-fix.
- Full `npm test` (unit + E2E via Docker Radicale): **591 passed, 30 suites**, coverage thresholds met. No regression to existing diff/reconcile/idempotency behavior.
- `npx tsc -noEmit -skipLibCheck` clean; `npm run lint` clean.
- wdio spec green (verified failing pre-fix, passing post-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)