### PR TITLE
docs(changelog): 1.6.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,30 @@
 
 ## Unreleased
 
+## 1.6.0
+
 ### Features
 
+- **CalDAV passwords are stored in Obsidian's secret storage** instead of plain text, on Obsidian versions that support it (#133 — thanks @LukasWestholt).
+- **Mobile support** with a per-device sync switch, so you can enable syncing selectively per device (#46, #134).
+- **Foreign VTODO properties are preserved on update.** Reminders (`VALARM`), `RELATED-TO`, `X-*` extensions, `PERCENT-COMPLETE`, and `VTIMEZONE` blocks written by other CalDAV clients now survive an Obsidian-side edit instead of being dropped, and `STATUS:IN-PROCESS` (e.g. from jtx Board) is kept rather than overwritten with `NEEDS-ACTION` on every sync (#147, supersedes #140 — thanks @LukasWestholt).
 - Per-calendar filter is now configured as two independent fields, **Obsidian tag** and **Server category** (#94, #98 — thanks @AlfHou). The previous single **Tag** field is split automatically on first launch; existing setups keep their behavior. Leaving **Server category** empty pulls every task on the server (useful when clients like the iOS Reminders app can't set CATEGORIES). Different values on each side are supported when your Obsidian tag and server category vocabularies differ.
 
 ### Bug Fixes
 
+- **Fixed a task-duplication loop.** When a task's ID drifts out of the id-mapping (an interrupted sync, a backup restore, multi-device use, or a from-scratch resync), the plugin now reconciles it to the task already on the server instead of creating a duplicate — which previously got pulled back into the vault and re-duplicated, amplifying on every sync (#149).
+- **Vault-side edits of pulled tasks are no longer reverted.** A task first pulled from the server now receives its stable Obsidian ID at discovery, so the sync baseline pairs with it correctly instead of treating later edits as no-baseline conflicts (#144).
+- VTODO sub-components (e.g. `VALARM`) are stripped before task properties are extracted, so reminder text no longer bleeds into the task summary or notes (#139).
+- `calendar-data` with attributes or an inline `xmlns` on the tag now parses correctly (Open-Xchange / mailbox.org / DavMail) (#137).
 - Convergent edits no longer trigger a conflict — when both sides independently change a task to the same value, the diff treats it as already resolved instead of forcing one side to overwrite the other (#106).
+- Corrected the DTSTART metadata mapping description in the README (#141).
 
 ### Infrastructure
 
+- **iCalendar parsing and serialization moved to the [`ical.js`](https://github.com/kewisch/ical.js) library** (the engine Thunderbird uses), for more robust VTODO handling and automatic round-tripping of properties the plugin doesn't manage (#145, #147).
+- **WebDAV multistatus responses are parsed with the built-in `DOMParser`** instead of hand-rolled regex, handling namespaces, CDATA, and attributed tags natively (#148).
 - Migrations now record which ones have already run (`appliedMigrations` in settings), so each migration executes at most once per install regardless of its own idempotency checks (#107).
+- Dependency updates (#146).
 
 ## 1.0.0
 


### PR DESCRIPTION
Adds the **1.6.0** section to `CHANGELOG.md`, covering everything merged since 1.5.0. Merge this before cutting the release so the tag ships with notes.

**Highlights**
- 🐛 Fixed the task-duplication loop (reconcile on ID drift) — #149
- 🐛 Pulled-task edits no longer reverted (stable ID at discovery) — #144
- ✨ Foreign VTODO properties + `STATUS:IN-PROCESS` preserved on update — #147
- ✨ CalDAV passwords in Obsidian secret storage — #133
- ✨ Mobile support with per-device sync switch — #134
- 🔧 iCalendar via ical.js (#145) and WebDAV XML via DOMParser (#148)

Carried over the previously-unreleased entries (#94/#98, #106, #107) into 1.6.0. Tweak wording/credits as you like before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)