### PR TITLE
fix(tasks): match sync tag in raw markdown when Tasks global filter consumes it

### DIFF
--- a/src/tasks/obsidianTasksWrapper.test.ts
+++ b/src/tasks/obsidianTasksWrapper.test.ts
@@ -722,6 +722,50 @@ More content`;
 
             expect(wrapper.filterByTag(inputs, 'sync')).toHaveLength(0);
         });
+
+        it('should match the sync tag in raw markdown when the Tasks global filter consumed it', () => {
+            // Tasks strips its global filter from task.tags. If the global filter
+            // equals the sync tag, matching on tags alone drops every task.
+            const inputs: TaskWithBody[] = [
+                withBody(createMockTask({
+                    description: 'Task 1',
+                    tags: [],
+                    originalMarkdown: '- [ ] Task 1 #sync',
+                })),
+                withBody(createMockTask({
+                    description: 'Task 2',
+                    tags: ['#work'],
+                    originalMarkdown: '- [ ] Task 2 #work #sync',
+                })),
+            ];
+
+            const result = wrapper.filterByTag(inputs, 'sync');
+            expect(result).toHaveLength(2);
+        });
+
+        it('should exclude tasks when the tag is in neither tags nor raw markdown', () => {
+            const inputs: TaskWithBody[] = [
+                withBody(createMockTask({ tags: [], originalMarkdown: '- [ ] Task without the tag' })),
+            ];
+
+            expect(wrapper.filterByTag(inputs, 'sync')).toHaveLength(0);
+        });
+
+        it('should not match a raw-markdown tag that merely starts with the sync tag', () => {
+            const inputs: TaskWithBody[] = [
+                withBody(createMockTask({ tags: [], originalMarkdown: '- [ ] Task #syncing' })),
+            ];
+
+            expect(wrapper.filterByTag(inputs, 'sync')).toHaveLength(0);
+        });
+
+        it('should match the raw-markdown tag case-insensitively', () => {
+            const inputs: TaskWithBody[] = [
+                withBody(createMockTask({ tags: [], originalMarkdown: '- [ ] Task #SYNC' })),
+            ];
+
+            expect(wrapper.filterByTag(inputs, 'sync')).toHaveLength(1);
+        });
     });
 
     describe('extractBodyFromFile', () => {

--- a/src/tasks/obsidianTasksWrapper.ts
+++ b/src/tasks/obsidianTasksWrapper.ts
@@ -393,16 +393,26 @@ export class ObsidianTasksWrapper {
      * Filter task inputs by sync tag.
      * Keeps only tasks whose tags include the given sync tag (case-insensitive).
      * Returns all inputs when syncTag is empty or undefined.
+     *
+     * Falls back to matching the tag in the task's raw markdown. When the Tasks
+     * plugin's global filter is set to the same tag as the sync tag, Tasks
+     * consumes it as the filter and it never appears in `task.tags`. Matching
+     * only against `task.tags` then drops every task, the adapter reports an
+     * empty vault, and a bidirectional sync deletes the entire remote list.
      */
     filterByTag(inputs: TaskWithBody[], syncTag?: string): TaskWithBody[] {
         if (!syncTag || syncTag.trim() === '') return inputs;
 
         const tagLower = syncTag.toLowerCase().replace(/^#/, '');
+        const escaped = tagLower.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const rawTagPattern = new RegExp(`(^|\\s)#${escaped}(\\s|$)`, 'i');
+
         return inputs.filter(({ task }) => {
-            if (!task.tags || task.tags.length === 0) return false;
-            return task.tags.some((tag: string) =>
+            const matchedTag = task.tags?.some((tag: string) =>
                 tag.toLowerCase().replace(/^#/, '') === tagLower
             );
+            if (matchedTag) return true;
+            return rawTagPattern.test(task.originalMarkdown ?? '');
         });
     }
 


### PR DESCRIPTION
## Problem

`filterByTag` matches only against `task.tags`. The obsidian-tasks plugin strips its configured **global filter** from the parsed tag list, so when a user sets their Tasks global filter to the same tag they use as the CalDAV `syncTag`, that tag never appears in `task.tags` — and every task is filtered out.

## Impact

The adapter then reports an empty vault. In a bidirectional calendar the diff reads that as *"every task was deleted locally"* and issues a DELETE for each one, emptying the remote list.

This is not hypothetical. Against a DavMail/Exchange calendar with both `globalFilter` and `syncTag` set to `#mstodo`, **25 tasks were deleted server-side** on the first sync after an Obsidian restart rebuilt the Tasks index and applied the global filter for the first time. The vault copy was untouched, so the data was recoverable from the plugin's own `baseline.json` — but the remote list was gone.

The trigger is subtle: setting the global filter does nothing until something forces a Tasks re-index, so the failure can lie dormant for days and then fire on an unrelated restart.

## Root cause

```ts
return inputs.filter(({ task }) => {
    if (!task.tags || task.tags.length === 0) return false;   // <- always true once the
    return task.tags.some(...)                                //    global filter ate the tag
});
```

## Fix

Fall back to matching the tag in `task.originalMarkdown` when it is absent from `task.tags`. Notes:

- The pattern is anchored on whitespace/string boundaries, so `#syncing` does not match a `sync` sync tag.
- The tag is regex-escaped before interpolation.
- Behaviour is unchanged whenever the tag *is* present in `task.tags` — this only adds a fallback.

Worth noting the write path already accounts for this collision: `applyChanges` threads `globalFilter` into `mapper.toMarkdown(...)`. This brings the read path in line.

## Tests

Four cases added to the existing `filterByTag` suite:

- matches when the global filter consumed the tag (tags empty, tag present in raw markdown)
- excludes when the tag is in neither `tags` nor raw markdown
- does not match a tag that merely *starts with* the sync tag (`#syncing` vs `sync`)
- raw-markdown matching is case-insensitive

`npx jest src/tasks/obsidianTasksWrapper.test.ts` → 73 passed. `src/sync/obsidianAdapter.test.ts` → 23 passed. `tsc -noEmit` and `eslint` clean.

## Reproducing

1. Set the obsidian-tasks global filter to `#foo`.
2. Configure a CalDAV calendar with `syncTag: #foo` and some tasks synced.
3. Reload the obsidian-tasks plugin (or restart Obsidian) so the index rebuilds with the global filter applied.
4. `obsidianAdapter.fetchTasks()` returns 0 despite a populated vault; the next sync deletes the remote tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)