### PR TITLE
feat(sync): implement deleteObsidian delete behavior with delete guard

### DIFF
--- a/src/sync/deleteGuard.test.ts
+++ b/src/sync/deleteGuard.test.ts
@@ -1,0 +1,79 @@
+import { guardDeletes } from './deleteGuard';
+import { Changeset, SyncChange, CommonTask } from './types';
+
+function change(type: SyncChange['type'], uid: string): SyncChange {
+  return { type, task: { uid, title: uid } as unknown as CommonTask };
+}
+
+function changeset(toObsidian: SyncChange[], toCalDAV: SyncChange[]): Changeset {
+  return { toObsidian, toCalDAV, conflicts: [] };
+}
+
+describe('guardDeletes', () => {
+  it('passes changes through untouched when nothing is suspicious', () => {
+    const cs = changeset(
+      [change('delete', 'a'), change('create', 'b')],
+      [change('delete', 'c'), change('update', 'd')],
+    );
+
+    const result = guardDeletes(cs, { obsidianCount: 20, caldavCount: 20, baselineCount: 20 });
+
+    expect(result.changes).toEqual(cs);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('suppresses toObsidian deletes when the CalDAV report is empty and baseline is populated', () => {
+    // A transient empty server REPORT must not wipe the vault's task lines.
+    const cs = changeset(
+      [change('delete', 'a'), change('delete', 'b'), change('create', 'c')],
+      [],
+    );
+
+    const result = guardDeletes(cs, { obsidianCount: 20, caldavCount: 0, baselineCount: 20 });
+
+    expect(result.changes.toObsidian.map((c) => c.type)).toEqual(['create']);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('allows toObsidian deletes when the CalDAV report is empty but baseline is tiny', () => {
+    // A user genuinely emptying a 2-task list is not an anomaly.
+    const cs = changeset([change('delete', 'a'), change('delete', 'b')], []);
+
+    const result = guardDeletes(cs, { obsidianCount: 2, caldavCount: 0, baselineCount: 2 });
+
+    expect(result.changes.toObsidian).toHaveLength(2);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('suppresses toCalDAV deletes when the Obsidian view is empty and baseline is populated', () => {
+    // The 2026-07-24 incident direction: a blind vault adapter must not
+    // push a DELETE for every baseline task to the server.
+    const cs = changeset([], Array.from({ length: 25 }, (_, i) => change('delete', `t${i}`)));
+
+    const result = guardDeletes(cs, { obsidianCount: 0, caldavCount: 25, baselineCount: 25 });
+
+    expect(result.changes.toCalDAV).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('suppresses deletes exceeding the per-cycle cap of max(10, half the baseline)', () => {
+    const deletes = Array.from({ length: 12 }, (_, i) => change('delete', `t${i}`));
+    const cs = changeset(deletes, []);
+
+    // baseline 20 → cap max(10, 10) = 10; 12 deletes exceeds it
+    const result = guardDeletes(cs, { obsidianCount: 8, caldavCount: 8, baselineCount: 20 });
+
+    expect(result.changes.toObsidian).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('allows delete batches under the cap', () => {
+    const deletes = Array.from({ length: 9 }, (_, i) => change('delete', `t${i}`));
+    const cs = changeset(deletes, []);
+
+    const result = guardDeletes(cs, { obsidianCount: 30, caldavCount: 21, baselineCount: 30 });
+
+    expect(result.changes.toObsidian).toHaveLength(9);
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/src/sync/deleteGuard.ts
+++ b/src/sync/deleteGuard.ts
@@ -1,0 +1,77 @@
+import { Changeset, SyncChange } from './types';
+
+export interface DeleteGuardCounts {
+  obsidianCount: number;
+  caldavCount: number;
+  baselineCount: number;
+}
+
+export interface DeleteGuardResult {
+  changes: Changeset;
+  warnings: string[];
+}
+
+/**
+ * Baselines at or below this size are exempt from the empty-side guard: a
+ * user genuinely clearing a tiny list is indistinguishable from an anomaly,
+ * and the blast radius is small either way.
+ */
+const MIN_BASELINE_FOR_GUARD = 3;
+
+/** Per-cycle delete cap floor; the effective cap is max(floor, baseline/2). */
+const DELETE_CAP_FLOOR = 10;
+
+const isDelete = (c: SyncChange): boolean => c.type === 'delete';
+
+/**
+ * Suppress delete batches that look like one side went blind rather than the
+ * user deleting tasks. Suppressed deletes are removed from the changeset
+ * BEFORE apply and BEFORE the baseline update, so the affected tasks stay in
+ * baseline and the same deletes are re-derived (and re-judged) next sync —
+ * fail closed, no data loss, retried loudly.
+ *
+ * Two triggers, applied independently per side:
+ * - the source side reported zero tasks while the baseline is populated
+ *   (a transient empty CalDAV REPORT, or a blind vault adapter — the
+ *   2026-07-24 mass-deletion incident direction), or
+ * - the delete batch exceeds max(10, half the baseline) in one cycle.
+ */
+export function guardDeletes(changeset: Changeset, counts: DeleteGuardCounts): DeleteGuardResult {
+  const warnings: string[] = [];
+  const cap = Math.max(DELETE_CAP_FLOOR, Math.ceil(counts.baselineCount / 2));
+
+  const guardSide = (
+    changes: SyncChange[],
+    sourceEmpty: boolean,
+    sourceName: string,
+    sideName: string,
+  ): SyncChange[] => {
+    const deletes = changes.filter(isDelete).length;
+    if (deletes === 0) return changes;
+
+    if (sourceEmpty && counts.baselineCount > MIN_BASELINE_FOR_GUARD) {
+      warnings.push(
+        `${sourceName} reported 0 tasks while baseline holds ${counts.baselineCount} — suppressed ${deletes} ${sideName} delete(s)`,
+      );
+      return changes.filter((c) => !isDelete(c));
+    }
+
+    if (deletes > cap) {
+      warnings.push(
+        `delete batch of ${deletes} exceeds per-cycle cap ${cap} — suppressed ${sideName} delete(s)`,
+      );
+      return changes.filter((c) => !isDelete(c));
+    }
+
+    return changes;
+  };
+
+  return {
+    changes: {
+      ...changeset,
+      toObsidian: guardSide(changeset.toObsidian, counts.caldavCount === 0, 'CalDAV', 'toObsidian'),
+      toCalDAV: guardSide(changeset.toCalDAV, counts.obsidianCount === 0, 'Obsidian', 'toCalDAV'),
+    },
+    warnings,
+  };
+}

--- a/src/sync/obsidianAdapter.test.ts
+++ b/src/sync/obsidianAdapter.test.ts
@@ -366,6 +366,59 @@ describe('ObsidianAdapter', () => {
     });
   });
 
+  describe('applyChanges — delete', () => {
+    function makeDeleteWrapper(task: ObsidianTask | null) {
+      return {
+        ...(dummyWrapper as unknown as Record<string, unknown>),
+        findTaskById: jest.fn().mockReturnValue(task),
+        removeTaskFromVault: jest.fn().mockResolvedValue(undefined),
+      } as unknown as ObsidianTasksWrapper;
+    }
+
+    const commonTask: CommonTask = {
+      uid: '20250105-a4f',
+      title: 'Buy groceries',
+      status: 'NEEDS-ACTION',
+      tags: [],
+    } as unknown as CommonTask;
+
+    it('removes the vault line when deleteBehavior is deleteObsidian', async () => {
+      const existing = makeTask();
+      const wrapper = makeDeleteWrapper(existing);
+      const adapter = new ObsidianAdapter(wrapper, {
+        ...defaultSettings,
+        deleteBehavior: 'deleteObsidian',
+      });
+
+      await adapter.applyChanges([{ type: 'delete', task: commonTask }]);
+
+      expect(wrapper.removeTaskFromVault).toHaveBeenCalledWith(existing);
+    });
+
+    it('leaves the vault untouched when deleteBehavior is not deleteObsidian', async () => {
+      const wrapper = makeDeleteWrapper(makeTask());
+      const adapter = new ObsidianAdapter(wrapper, defaultSettings);
+
+      await adapter.applyChanges([{ type: 'delete', task: commonTask }]);
+
+      expect(wrapper.removeTaskFromVault).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when the task cannot be found in the vault', async () => {
+      const wrapper = makeDeleteWrapper(null);
+      const adapter = new ObsidianAdapter(wrapper, {
+        ...defaultSettings,
+        deleteBehavior: 'deleteObsidian',
+      });
+
+      await expect(
+        adapter.applyChanges([{ type: 'delete', task: commonTask }])
+      ).resolves.toBeDefined();
+
+      expect(wrapper.removeTaskFromVault).not.toHaveBeenCalled();
+    });
+  });
+
   describe('applyChanges — complete', () => {
     it('calls executeToggleTaskDoneCommand for complete changes', async () => {
       const toggleFn = jest.fn().mockReturnValue(

--- a/src/sync/obsidianAdapter.ts
+++ b/src/sync/obsidianAdapter.ts
@@ -19,6 +19,9 @@ export interface ObsidianSyncSettings {
 	newTasksDestination: string;
 	newTasksSection?: string;
 	includeObsidianLink?: boolean;
+	// Only 'deleteObsidian' makes a CalDAV-side deletion remove the vault line;
+	// every other value keeps the historical leave-the-line behavior.
+	deleteBehavior?: string;
 	// Called at normalize time so vault renames are picked up without reconstructing the adapter.
 	getVaultName?: () => string;
 }
@@ -207,7 +210,19 @@ export class ObsidianAdapter {
 					}
 
 					case "delete": {
-						// Return mapping removal info — SyncEngine handles storage
+						// Mapping/baseline removal is SyncEngine's job; the vault
+						// line is ours, and only under an explicit opt-in. Servers
+						// that hide completed VTODOs (DavMail/Exchange) surface
+						// completions as deletions — leaving the line makes the
+						// task re-push as new on the next sync (resurrection).
+						if (this.settings.deleteBehavior !== "deleteObsidian") break;
+
+						const existingTask =
+							this.tasksById.get(change.task.uid) ??
+							this.wrapper.findTaskById(change.task.uid);
+						if (!existingTask) break;
+
+						await this.wrapper.removeTaskFromVault(existingTask);
 						break;
 					}
 					case "reconcile":

--- a/src/sync/syncEngine.test.ts
+++ b/src/sync/syncEngine.test.ts
@@ -86,6 +86,7 @@ const mockGetAllTasksWithBody = jest.fn().mockResolvedValue([]);
 const mockFindTaskById = jest.fn().mockReturnValue(null);
 const mockCreateTask = jest.fn().mockResolvedValue(undefined);
 const mockUpdateTaskInVault = jest.fn().mockResolvedValue(undefined);
+const mockRemoveTaskFromVault = jest.fn().mockResolvedValue(undefined);
 const mockGetTaskId = jest.fn().mockImplementation((task: ObsidianTask) => task.id || null);
 const mockFilterByTag = jest.fn().mockImplementation(
   (inputs: Array<{ task: ObsidianTask }>, syncTag?: string) => {
@@ -113,6 +114,7 @@ jest.mock('../tasks/obsidianTasksWrapper', () => ({
     findTaskById: mockFindTaskById,
     createTask: mockCreateTask,
     updateTaskInVault: mockUpdateTaskInVault,
+    removeTaskFromVault: mockRemoveTaskFromVault,
     getTaskId: mockGetTaskId,
     filterByTag: mockFilterByTag,
     extractId: mockExtractId,
@@ -2014,6 +2016,71 @@ describe('SyncEngine', () => {
       expect(result.success).toBe(true);
       expect(updates[0]).toEqual({ pullDone: 0, pullTotal: 1, pushDone: 0, pushTotal: 1 });
       expect(updates[updates.length - 1]).toEqual({ pullDone: 1, pullTotal: 1, pushDone: 1, pushTotal: 1 });
+    });
+  });
+
+  describe('deleteObsidian behavior', () => {
+    const vaultTask = () => ({
+      task: makeObsidianTask({
+        description: 'Completed on phone',
+        originalMarkdown: '- [ ] Completed on phone [id::20250101-abc] #sync',
+      }),
+      body: '',
+    });
+
+    const baselineEntry = (uid: string, title: string): CommonTask => ({
+      uid,
+      title,
+      status: 'NEEDS-ACTION',
+      tags: [],
+      body: '',
+    } as unknown as CommonTask);
+
+    it('removes the vault line when a baseline task disappears from a non-empty server report', async () => {
+      // Server still lists another task (report healthy), but the baseline
+      // task the vault holds is gone — completed on the phone.
+      mockFetchVTODOs.mockResolvedValue([makeCalObj('other-uid', 'Still active')]);
+      mockGetAllTasksWithBody.mockResolvedValue([vaultTask()]);
+      mockGetBaseline.mockReturnValue([
+        baselineEntry('20250101-abc', 'Completed on phone'),
+        baselineEntry('other-uid', 'Still active'),
+      ]);
+
+      const engine = new SyncEngine(
+        new App(),
+        makeCalendarMapping(),
+        makeSettings({ deleteBehavior: 'deleteObsidian' }),
+      );
+      await engine.initialize();
+      const result = await engine.sync();
+
+      expect(result.success).toBe(true);
+      expect(mockRemoveTaskFromVault).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses vault-line deletes when the server report is empty and baseline is populated', async () => {
+      // A transient empty REPORT must not wipe the vault's task lines; the
+      // suppressed delete stays in baseline and is re-derived next sync.
+      mockFetchVTODOs.mockResolvedValue([]);
+      mockGetAllTasksWithBody.mockResolvedValue([vaultTask()]);
+      mockGetBaseline.mockReturnValue([
+        baselineEntry('20250101-abc', 'Completed on phone'),
+        baselineEntry('b1', 'One'),
+        baselineEntry('b2', 'Two'),
+        baselineEntry('b3', 'Three'),
+        baselineEntry('b4', 'Four'),
+      ]);
+
+      const engine = new SyncEngine(
+        new App(),
+        makeCalendarMapping(),
+        makeSettings({ deleteBehavior: 'deleteObsidian' }),
+      );
+      await engine.initialize();
+      const result = await engine.sync();
+
+      expect(result.success).toBe(true);
+      expect(mockRemoveTaskFromVault).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -7,6 +7,7 @@ import { CalDAVAdapter } from "./caldavAdapter";
 import { ObsidianAdapter } from "./obsidianAdapter";
 import { diff } from "./diff";
 import { applicableChanges } from "./applicableChanges";
+import { guardDeletes } from "./deleteGuard";
 import { SyncProgress } from "./progress";
 import { CommonTask, Conflict, ConflictStrategy, SyncChange } from "./types";
 import { storageIdForCalendar } from "../utils/calendarStorageId";
@@ -61,6 +62,7 @@ export class SyncEngine {
 			newTasksDestination: settings.newTasksDestination,
 			newTasksSection: settings.newTasksSection,
 			includeObsidianLink: settings.includeObsidianLink,
+			deleteBehavior: settings.deleteBehavior,
 			getVaultName: () => app.vault.getName(),
 		});
 	}
@@ -88,7 +90,22 @@ export class SyncEngine {
 			const baseline = this.getOrSeedBaseline(obsidianTasks, caldavTasks, idMapping);
 
 			const changeset = diff(obsidianTasks, caldavTasks, baseline, this.conflictStrategy());
-			const applicable = applicableChanges(changeset, this.direction());
+			// Guard before apply AND before the baseline update: suppressed
+			// deletes stay in baseline, so they are re-derived (and re-judged)
+			// on the next sync instead of leaking as spurious creates.
+			const guarded = guardDeletes(
+				applicableChanges(changeset, this.direction()),
+				{
+					obsidianCount: obsidianTasks.length,
+					caldavCount: caldavTasks.length,
+					baselineCount: baseline.length,
+				},
+			);
+			const applicable = guarded.changes;
+			for (const warning of guarded.warnings) {
+				console.error(`[tasks-caldav-sync] delete guard: ${warning}`);
+				new Notice(`CalDAV sync (${calendarLabel(this.calendar)}): ${warning}`);
+			}
 
 			if (dryRun) return this.buildResult(applicable, obsidianTasks, caldavTasks, baseline, true, showProgress);
 

--- a/src/tasks/obsidianTasksWrapper.test.ts
+++ b/src/tasks/obsidianTasksWrapper.test.ts
@@ -394,6 +394,55 @@ describe('ObsidianTasksWrapper', () => {
         });
     });
 
+    describe('removeTaskFromVault', () => {
+        let mockFile: MockTFile;
+
+        beforeEach(() => {
+            mockFile = new MockTFile('test.md');
+            jest.clearAllMocks();
+        });
+
+        it('removes the task line and its indented note lines', async () => {
+            const fileContent = [
+                '- [ ] First task',
+                '- [ ] Target task to remove',
+                '  - note line under target',
+                '- [ ] Another task',
+            ].join('\n');
+
+            const task = createMockTask({
+                originalMarkdown: '- [ ] Target task to remove',
+                taskLocation: {
+                    path: 'test.md',
+                    _lineNumber: 9, // stale cache line number — must find by markdown
+                },
+            });
+
+            mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+            mockApp.vault.read.mockResolvedValue(fileContent);
+            mockApp.vault.modify.mockResolvedValue(undefined);
+
+            await wrapper.removeTaskFromVault(task);
+
+            const updated = (mockApp.vault.modify.mock.calls[0] as [unknown, string])[1];
+            expect(updated.split('\n')).toEqual([
+                '- [ ] First task',
+                '- [ ] Another task',
+            ]);
+        });
+
+        it('is a no-op when the task line is already gone', async () => {
+            mockApp.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+            mockApp.vault.read.mockResolvedValue('- [ ] Something else');
+
+            await wrapper.removeTaskFromVault(
+                createMockTask({ originalMarkdown: '- [ ] Gone task' })
+            );
+
+            expect(mockApp.vault.modify).not.toHaveBeenCalled();
+        });
+    });
+
     describe('updateTaskInVault', () => {
         let mockFile: MockTFile;
 

--- a/src/tasks/obsidianTasksWrapper.ts
+++ b/src/tasks/obsidianTasksWrapper.ts
@@ -224,6 +224,40 @@ export class ObsidianTasksWrapper {
     }
 
     /**
+     * Remove a task's line (and its indented note lines) from the vault.
+     * A missing line is success: the desired end state is already in place.
+     */
+    async removeTaskFromVault(task: ObsidianTask): Promise<void> {
+        const filePath = task.taskLocation.path;
+
+        const file = this.app.vault.getAbstractFileByPath(filePath);
+        if (!file || !(file instanceof TFile)) {
+            throw new Error(`File not found: ${filePath}`);
+        }
+
+        const content = await this.app.vault.read(file);
+        const lines = content.split('\n');
+
+        // Find the task by its original markdown (don't trust line numbers from cache)
+        const originalMarkdown = task.originalMarkdown;
+        const taskIndex = lines.findIndex(line => line.trim() === originalMarkdown.trim());
+        if (taskIndex === -1) return;
+
+        // Count indented note lines below the task
+        let noteLineCount = 0;
+        for (let i = taskIndex + 1; i < lines.length; i++) {
+            if (/^(?:\s{2,}|\t)- /.test(lines[i])) {
+                noteLineCount++;
+            } else {
+                break;
+            }
+        }
+
+        lines.splice(taskIndex, 1 + noteLineCount);
+        await this.app.vault.modify(file, lines.join('\n'));
+    }
+
+    /**
      * Create a new task in the destination file
      * @param taskContent The task markdown (e.g., "- [ ] New task")
      * @param destinationPath Path to the file where task should be added


### PR DESCRIPTION
Fixes #157.

`deleteBehavior` is declared in settings but never read by the engine, and the Obsidian-side apply treats `delete` changes as a no-op while SyncEngine still drops the task from baseline. Against servers that hide completed VTODOs (DavMail/Exchange → MS To Do), every completion made outside the vault resurrects two syncs later: the orphaned vault line, no longer in baseline, is pushed back to the server as a brand-new task (details and observed timeline in #157).

## What this does

- `ObsidianAdapter.applyChanges` `delete` now removes the vault line (plus its indented note lines) when `deleteBehavior === 'deleteObsidian'`. Every other value keeps the historical leave-the-line behavior, so nothing changes for existing users unless they opt in.
- `removeTaskFromVault` locates the task by `originalMarkdown` (stale cached line numbers are not trusted); an already-missing line is treated as success.
- New `guardDeletes()` (src/sync/deleteGuard.ts) suppresses delete batches that look like a blind side rather than user intent, in **both** directions:
  - a source side reporting **zero tasks against a populated baseline** (a transient empty CalDAV REPORT would otherwise wipe every synced vault line now that deletes are real; the mirror direction protects the server from a blind vault adapter);
  - a batch exceeding **max(10, half the baseline)** in one cycle.

  Suppressed deletes are stripped **before apply and before the baseline update**, so they stay in baseline and are re-derived (and re-judged) on the next sync — fail closed, loud (console + Notice), no data loss.

## Tests

- unit tests for the guard (6), the adapter delete case (3), `removeTaskFromVault` (2), and engine-level wiring incl. the empty-report suppression path (2) — all written red-first
- full unit suite green (562 tests)

Verified end-to-end against a live DavMail → Exchange Online stack: server-side `PUT STATUS:COMPLETED` → vault line removed on next sync → no resurrection on the sync after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)