### PR TITLE
fix(tasks): filterByTag falls back to originalMarkdown when the global filter consumed the sync tag

### DIFF
--- a/src/tasks/obsidianTasksWrapper.test.ts
+++ b/src/tasks/obsidianTasksWrapper.test.ts
@@ -707,6 +707,32 @@ More content`;
             expect(wrapper.filterByTag(inputs, 'sync')).toHaveLength(2);
         });
 
+        it('falls back to originalMarkdown when the global filter consumed the sync tag from tags[]', () => {
+            // obsidian-tasks strips its globalFilter tag out of task.tags; when the
+            // global filter equals the sync tag, tag-array matching alone sees nothing.
+            const inputs: TaskWithBody[] = [
+                withBody(createMockTask({
+                    description: 'Stripped',
+                    tags: [],
+                    originalMarkdown: '- [ ] Stripped #mstodo 🆔 20260806-0001',
+                })),
+                withBody(createMockTask({
+                    description: 'Unrelated',
+                    tags: [],
+                    originalMarkdown: '- [ ] Unrelated #other',
+                })),
+                withBody(createMockTask({
+                    description: 'Prefix only',
+                    tags: [],
+                    originalMarkdown: '- [ ] Prefix only #mstodo2',
+                })),
+            ];
+
+            const result = wrapper.filterByTag(inputs, '#mstodo');
+            expect(result).toHaveLength(1);
+            expect(result[0].task.description).toBe('Stripped');
+        });
+
         it('should handle syncTag with # prefix', () => {
             const inputs: TaskWithBody[] = [
                 withBody(createMockTask({ tags: ['#sync'] })),

--- a/src/tasks/obsidianTasksWrapper.ts
+++ b/src/tasks/obsidianTasksWrapper.ts
@@ -398,11 +398,19 @@ export class ObsidianTasksWrapper {
         if (!syncTag || syncTag.trim() === '') return inputs;
 
         const tagLower = syncTag.toLowerCase().replace(/^#/, '');
+        // obsidian-tasks consumes its globalFilter tag out of task.tags; when the
+        // global filter equals the sync tag, tag-array matching sees an empty
+        // vault and every baseline task becomes a server-side delete. Fall back
+        // to the raw markdown line before giving up on a task.
         return inputs.filter(({ task }) => {
-            if (!task.tags || task.tags.length === 0) return false;
-            return task.tags.some((tag: string) =>
+            if (task.tags && task.tags.some((tag: string) =>
                 tag.toLowerCase().replace(/^#/, '') === tagLower
-            );
+            )) return true;
+            const raw = String(task.originalMarkdown || '');
+            return new RegExp(
+                '(^|\\s)#' + tagLower.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(\\s|$)',
+                'i'
+            ).test(raw);
         });
     }
 


### PR DESCRIPTION
obsidian-tasks strips its `globalFilter` tag out of `task.tags`. When a user sets the Tasks global filter to the **same tag** as the CalDAV sync tag — a natural configuration for a dedicated sync tag — `filterByTag` matches nothing: the adapter reports an empty vault against a populated baseline, and every baseline task is pushed to the server as a DELETE, emptying the remote list. This happened to a live MS To Do list (via DavMail/Exchange) on 2026-07-24.

The write path already threads `globalFilter` into `toMarkdown` to handle exactly this collision; the read path missed it. This falls back to matching the sync tag against `task.originalMarkdown` (word-boundary, case-insensitive, regex-escaped) before excluding a task.

Test covers the stripped-tag fallback, a non-matching tag, and the prefix case (`#mstodo2` must not match `#mstodo`). Full unit suite green.

We have been running this patch in production against DavMail since 2026-07-25 with no duplicate or misclassification issues.

Note: independent of #158, but the same failure mode is what its `guardDeletes()` catches as a second line of defense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)